### PR TITLE
(#34) Promote BufferPool to explicit ComputeContext

### DIFF
--- a/changelog.d/34.changed.rst
+++ b/changelog.d/34.changed.rst
@@ -1,0 +1,10 @@
+``BufferPool`` and the worker-local tile cache are now reached through an
+explicit ``pycsa.compute.ComputeContext`` dataclass threaded through the
+pipeline (``get_pmf`` / ``first_appx`` / ``second_appx`` / ``f_trans`` /
+``lin_reg.do`` / ``lin_reg.get_coeffs``). Replaces the previous pattern
+of implicit ``BufferPool()`` construction inside ``get_pmf.__init__`` and
+module-global ``tile_cache.get_worker_cache()`` calls in ``do_cell``.
+
+The legacy ``buffer_pool=`` keyword on ``f_trans`` / ``lin_reg`` is
+retained as a deprecated alias for one release; passing it emits a
+``DeprecationWarning``.

--- a/pycsa/compute/__init__.py
+++ b/pycsa/compute/__init__.py
@@ -1,0 +1,10 @@
+"""Compute-pipeline plumbing.
+
+Currently exposes ``ComputeContext`` — an explicit container for
+per-task compute resources (buffer pool + tile-cache accessor) threaded
+through the CSA pipeline.
+"""
+
+from pycsa.compute.context import ComputeContext
+
+__all__ = ["ComputeContext"]

--- a/pycsa/compute/context.py
+++ b/pycsa/compute/context.py
@@ -1,0 +1,79 @@
+"""ComputeContext: explicit container for per-task compute resources.
+
+Bundles the ``BufferPool`` (per-task lifetime; owned by the context) and an
+accessor for the worker-local tile cache (worker-process lifetime; the
+context only holds a getter). Threading a single ctx through the pipeline
+makes the data flow explicit, replacing the previous pattern of implicit
+``BufferPool`` creation inside ``get_pmf.__init__`` + module-level
+``tile_cache.get_worker_cache()`` calls scattered through ``do_cell``.
+
+The tile_cache field is a *callable* rather than the cache itself because
+the real cache is a per-Dask-worker singleton owned by the worker process
+and can't be carried across pickle boundaries. A test can substitute a
+stub by passing any callable that returns a cache-like object.
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional
+
+from pycsa.core.buffer_pool import BufferPool
+
+
+@dataclass
+class ComputeContext:
+    """Per-task compute resources for the CSA pipeline.
+
+    Parameters
+    ----------
+    buffer_pool
+        Owned by the context. One ``BufferPool`` per ``ComputeContext``.
+    tile_cache
+        Optional callable that returns the worker-local tile cache. The
+        cache itself is not stored (it's owned by the Dask worker process);
+        we hold a getter that resolves at call time. Pass ``None`` for
+        environments that don't need tile_cache (idealised runs, tests).
+    """
+
+    buffer_pool: BufferPool = field(default_factory=BufferPool)
+    tile_cache: Optional[Callable[[], Any]] = None
+
+    @classmethod
+    def default(cls) -> "ComputeContext":
+        """Production setup: fresh ``BufferPool`` + tile_cache accessor.
+
+        Imports ``pycsa.core.tile_cache`` lazily so callers in
+        dependency-light environments can still construct a no-cache
+        context via plain ``ComputeContext()``.
+        """
+        try:
+            from pycsa.core.tile_cache import get_worker_cache
+
+            return cls(buffer_pool=BufferPool(), tile_cache=get_worker_cache)
+        except ImportError:
+            return cls(buffer_pool=BufferPool(), tile_cache=None)
+
+
+def _resolve_ctx(
+    ctx: Optional[ComputeContext], buffer_pool: Optional[BufferPool]
+) -> ComputeContext:
+    """Backward-compat shim for callers still passing ``buffer_pool=``.
+
+    Internal helper used by ``f_trans`` / ``lin_reg`` to accept either the
+    new ``ctx=`` kwarg or the legacy ``buffer_pool=`` kwarg during the
+    deprecation window. Emits a ``DeprecationWarning`` if the legacy form
+    is used. Default-constructs a context when neither is supplied.
+    """
+    if ctx is not None:
+        return ctx
+    if buffer_pool is not None:
+        warnings.warn(
+            "buffer_pool= is deprecated; pass ctx=ComputeContext(buffer_pool=...) "
+            "instead. The legacy kwarg will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        return ComputeContext(buffer_pool=buffer_pool)
+    return ComputeContext()

--- a/pycsa/core/fourier.py
+++ b/pycsa/core/fourier.py
@@ -38,7 +38,7 @@ class f_trans(object):
     Fourier transformer class
     """
 
-    def __init__(self, nhar_i, nhar_j, buffer_pool=None):
+    def __init__(self, nhar_i, nhar_j, ctx=None, buffer_pool=None):
         """
         Initalises a discrete spectral space with the corresponding Fourier coefficients spanning ``nhar_i`` and ``nhar_j``.
 
@@ -48,12 +48,21 @@ class f_trans(object):
             number of spectral modes in the first horizontal direction
         nhar_j : int
             number of spectral modes in the second horizontal direction
+        ctx : ComputeContext, optional
+            Compute context bundling the buffer pool (and other per-task
+            resources). Default-constructed if absent.
         buffer_pool : BufferPool, optional
-            Buffer pool for memory-efficient array reuse
+            **Deprecated.** Pass ``ctx=ComputeContext(buffer_pool=...)``
+            instead. Retained as a compatibility alias for one release.
         """
+        from pycsa.compute.context import _resolve_ctx
+
         self.nhar_i = nhar_i
         self.nhar_j = nhar_j
-        self.buffer_pool = buffer_pool
+        self.ctx = _resolve_ctx(ctx, buffer_pool)
+        # `self.buffer_pool` retained as a read-only alias so call sites that
+        # already reference `fobj.buffer_pool` continue to work.
+        self.buffer_pool = self.ctx.buffer_pool
 
         self.m_i = None
         self.m_j = None

--- a/pycsa/core/lin_reg.py
+++ b/pycsa/core/lin_reg.py
@@ -10,21 +10,33 @@ from scipy.sparse import csr_matrix, eye
 from scipy.sparse.linalg import spsolve
 
 
-def get_coeffs(fobj, buffer_pool=None):
+def get_coeffs(fobj, ctx=None, buffer_pool=None):
     """Assembles the Fourier coefficients from the sine and cosine terms generated in the :class:`Fourier transformer class <src.fourier.f_trans>`.
 
     Parameters
     ----------
     fobj : :class:`src.fourier.f_trans` instance
         instance of the Fourier transformer class.
+    ctx : ComputeContext, optional
+        Compute context bundling the buffer pool. If absent, defaults to
+        ``fobj.ctx`` (set by ``f_trans.__init__``).
     buffer_pool : BufferPool, optional
-        Buffer pool for memory-efficient array reuse
+        **Deprecated.** Pass ``ctx=ComputeContext(buffer_pool=...)`` instead.
 
     Returns
     -------
     array-like
         2D array corresponding to the ``M`` matrix.
     """
+    from pycsa.compute.context import _resolve_ctx
+
+    if ctx is None and buffer_pool is None:
+        # Inherit from fobj when neither is explicitly supplied — that's
+        # the common path now that f_trans owns a ctx.
+        ctx = getattr(fobj, "ctx", None)
+    ctx = _resolve_ctx(ctx, buffer_pool)
+    buffer_pool = ctx.buffer_pool
+
     Ncos = fobj.bf_cos
     Nsin = fobj.bf_sin
 
@@ -64,6 +76,7 @@ def do(
     lmbda=0.0,
     iter_solve=True,
     save_coeffs=False,
+    ctx=None,
     buffer_pool=None,
     use_sparse=False,
 ):
@@ -82,8 +95,11 @@ def do(
         toggles between using direct or iterative solver, by default True
     save_coeffs : bool, optional
         skips the linear regression and just saves the generated ``M`` matrix for diagnostics and debugging, by default False
+    ctx : ComputeContext, optional
+        Compute context bundling the buffer pool. If absent, defaults to
+        ``fobj.ctx``.
     buffer_pool : BufferPool, optional
-        Buffer pool for memory-efficient array reuse
+        **Deprecated.** Pass ``ctx=ComputeContext(buffer_pool=...)`` instead.
     use_sparse : bool, optional
         Use sparse matrix solver (automatic for few modes), by default False
 
@@ -94,13 +110,20 @@ def do(
     data_recons : like
         vector-like topography reconstructed from ``a_m``
     """
+    from pycsa.compute.context import _resolve_ctx
+
+    if ctx is None and buffer_pool is None:
+        ctx = getattr(fobj, "ctx", None)
+    ctx = _resolve_ctx(ctx, buffer_pool)
+    buffer_pool = ctx.buffer_pool
+
     if fobj.grad:
         cell.get_grad()
         data = cell.grad_topo_m
     else:
         data = cell.topo_m
 
-    coeff = get_coeffs(fobj, buffer_pool)
+    coeff = get_coeffs(fobj, ctx=ctx)
 
     if save_coeffs:
         fobj.coeff = coeff

--- a/pycsa/wrappers/interface.py
+++ b/pycsa/wrappers/interface.py
@@ -14,7 +14,7 @@ class get_pmf(object):
     This class is used in the idealised experiments
     """
 
-    def __init__(self, nhi, nhj, U, V, debug=False):
+    def __init__(self, nhi, nhj, U, V, debug=False, ctx=None):
         """
 
         Parameters
@@ -29,14 +29,22 @@ class get_pmf(object):
             wind speed in the second horizontal direction
         debug : bool, optional
             debug flag, by default False
+        ctx : ComputeContext, optional
+            Compute context bundling the buffer pool (and other per-task
+            resources). Default-constructed if absent — preserves the
+            previous behavior of one fresh BufferPool per ``get_pmf``
+            instance. Pass an explicit ctx to share resources across
+            multiple ``get_pmf`` instances (e.g. FA + SA in ``do_cell``).
         """
-        # Initialize buffer pool for memory-efficient array reuse
-        from pycsa.core.buffer_pool import BufferPool
+        from pycsa.compute.context import ComputeContext
 
-        self.buffer_pool = BufferPool()
+        self.ctx = ctx if ctx is not None else ComputeContext()
+        # Retained as an alias so callers that introspect
+        # ``get_pmf_instance.buffer_pool`` continue to work.
+        self.buffer_pool = self.ctx.buffer_pool
 
-        # Initialize Fourier transformer with buffer pool
-        self.fobj = fourier.f_trans(nhi, nhj, buffer_pool=self.buffer_pool)
+        # Initialize Fourier transformer with the shared ctx
+        self.fobj = fourier.f_trans(nhi, nhj, ctx=self.ctx)
 
         self.U = U
         self.V = V
@@ -64,7 +72,7 @@ class get_pmf(object):
             lmbda,
             kwargs.get("iter_solve", True),
             kwargs.get("save_coeffs", False),
-            buffer_pool=self.buffer_pool,
+            ctx=self.ctx,
             use_sparse=kwargs.get("use_sparse", False),
         )
 
@@ -81,7 +89,7 @@ class get_pmf(object):
                 cell,
                 lmbda,
                 kwargs.get("iter_solve", True),
-                buffer_pool=self.buffer_pool,
+                ctx=self.ctx,
             )
 
             self.fobj.get_freq_grid(am)
@@ -356,7 +364,7 @@ class first_appx(object):
     Use this routine to apply tapering and to separate the first and second approximation steps
     """
 
-    def __init__(self, nhi, nhj, params, topo):
+    def __init__(self, nhi, nhj, params, topo, ctx=None):
         """
         Parameters
         ----------
@@ -368,10 +376,14 @@ class first_appx(object):
             instance of the user-defined parameters class
         topo : :class:`src.var.topo` or :class:`src.var.topo_cell`
             instance of an object with topography attribute
+        ctx : ComputeContext, optional
+            Compute context shared with the inner ``get_pmf`` call.
+            Default-constructed if absent.
         """
         self.nhi, self.nhj = nhi, nhj
         self.params = params
         self.topo = topo
+        self.ctx = ctx
 
     def do(self, simplex_lat, simplex_lon, res_topo=None, use_center=True):
         """Do the First Approximation step
@@ -427,7 +439,9 @@ class first_appx(object):
                 use_center=use_center,
             )
 
-        first_guess = get_pmf(self.nhi, self.nhj, self.params.U, self.params.V)
+        first_guess = get_pmf(
+            self.nhi, self.nhj, self.params.U, self.params.V, ctx=self.ctx
+        )
 
         ampls_fa, uw_fa, dat_2D_fa = first_guess.sappx(
             cell_fa, lmbda=self.params.lmbda_fa, iter_solve=self.params.fa_iter_solve
@@ -441,7 +455,7 @@ class second_appx(object):
     Use this routine to apply tapering and to separate the first and second approximation steps
     """
 
-    def __init__(self, nhi, nhj, params, topo, tri):
+    def __init__(self, nhi, nhj, params, topo, tri, ctx=None):
         """
         Parameters
         ----------
@@ -455,11 +469,15 @@ class second_appx(object):
             instance of an object with topography attribute
         tri : :class:`scipy.spatial.qhull.Delaunay`
             instance of the scipy Delaunay triangulation class
+        ctx : ComputeContext, optional
+            Compute context shared with the inner ``get_pmf`` call.
+            Default-constructed if absent.
         """
         self.params = params
         self.topo = topo
         self.tri = tri
         self.nhi, self.nhj = nhi, nhj
+        self.ctx = ctx
         self.n_modes = params.n_modes
 
     def do(self, idx, ampls_fa, res_topo=None, use_center=True):
@@ -531,7 +549,9 @@ class second_appx(object):
                 res_topo=res_topo,
             )
 
-        second_guess = get_pmf(self.nhi, self.nhj, self.params.U, self.params.V)
+        second_guess = get_pmf(
+            self.nhi, self.nhj, self.params.U, self.params.V, ctx=self.ctx
+        )
 
         indices = []
         modes_cnt = 0

--- a/runs/icon_etopo_global.py
+++ b/runs/icon_etopo_global.py
@@ -262,6 +262,16 @@ def do_cell(
     try:
         logger.info(f"[START] Processing cell {c_idx}")
 
+        # Compute context: one BufferPool per cell, shared across the FA/SA
+        # get_pmf instances below; tile_cache accessor resolves to the
+        # worker-local singleton initialised by client.run(...) in the main
+        # loop. Explicit ctx replaces the previous pattern of implicit
+        # BufferPool creation inside each get_pmf + module-global access to
+        # tile_cache.get_worker_cache.
+        from pycsa.compute import ComputeContext
+
+        ctx = ComputeContext.default()
+
         topo = var.topo_cell()
 
         lat_verts = grid.clat_vertices[c_idx]
@@ -277,7 +287,7 @@ def do_cell(
         # The cache is initialised once per memory batch via init_worker_cache
         # (see the per-batch loop below); handles stay open across cells in
         # the same worker so we don't re-open the same ETOPO tile per cell.
-        cache = tile_cache.get_worker_cache()
+        cache = ctx.tile_cache()
         topo.lat, topo.lon, topo.topo = cache.get_etopo_data(
             lat_extent, lon_extent, etopo_cg=params.etopo_cg
         )
@@ -322,8 +332,8 @@ def do_cell(
         nhi = params.nhi
         nhj = params.nhj
 
-        fa = interface.first_appx(nhi, nhj, params, topo)
-        sa = interface.second_appx(nhi, nhj, params, topo, tri)
+        fa = interface.first_appx(nhi, nhj, params, topo, ctx=ctx)
+        sa = interface.second_appx(nhi, nhj, params, topo, tri, ctx=ctx)
 
         tri.tri_lon_verts = triangles[:, :, 0]
         tri.tri_lat_verts = triangles[:, :, 1]
@@ -389,7 +399,9 @@ def do_cell(
             )
 
             # Run SA with ALL wavenumbers
-            sa_pmf = interface.get_pmf(params.nhi, params.nhj, params.U, params.V)
+            sa_pmf = interface.get_pmf(
+                params.nhi, params.nhj, params.U, params.V, ctx=ctx
+            )
             ampls_sa, uw_sa, dat_2D_sa = sa_pmf.sappx(
                 cell_sa,
                 lmbda=params.lmbda_sa,


### PR DESCRIPTION
Closes #34. Second of four Phase B refactors gated by the reproducibility suite (#31).

## What changed

| file | change |
|---|---|
| `pycsa/compute/__init__.py`, `pycsa/compute/context.py` | **New.** `ComputeContext` `@dataclass` with `buffer_pool: BufferPool` (owned) + `tile_cache: Callable` (accessor for the per-Dask-worker singleton — the cache lifetime belongs to the worker process). Factory `default()` wires the production tile_cache accessor lazily. `_resolve_ctx` shim handles the deprecated `buffer_pool=` kwarg. |
| `pycsa/wrappers/interface.py` | `get_pmf.__init__` accepts `ctx=None`, default-constructs if absent. `first_appx.__init__` / `second_appx.__init__` take and forward `ctx`. Inner `get_pmf` / `lin_reg.do` calls pass `ctx=self.ctx`. |
| `pycsa/core/fourier.py` | `f_trans.__init__` takes `ctx=None, buffer_pool=None`; resolves via `_resolve_ctx`. `self.buffer_pool` retained as an alias. |
| `pycsa/core/lin_reg.py` | `get_coeffs` and `do` take `ctx=None, buffer_pool=None`; default to `fobj.ctx`. |
| `runs/icon_etopo_global.py` | `do_cell` constructs `ctx = ComputeContext.default()` once per cell. FA / SA share that ctx; the tile-cache lookup goes through `ctx.tile_cache()` instead of module-global `tile_cache.get_worker_cache()`. |
| `changelog.d/34.changed.rst` | towncrier fragment. |

## Acceptance (all met locally)

- [x] `grep -rn 'BufferPool()' pycsa/` returns only docstring examples in `buffer_pool.py` + the factory in `compute/context.py` — no bare instantiations elsewhere.
- [x] `do_cell` no longer reaches into module-global state for the cache; access is via `ctx.tile_cache()`.
- [x] `pytest tests/reproducibility/ -v` → 3 passed in 14.3 s. Numerics unchanged (the refactor is pure plumbing).
- [x] `python -c "import runs.icon_etopo_global"` → clean import.
- [x] Back-compat: passing the deprecated `buffer_pool=` kwarg fires `DeprecationWarning` via `_resolve_ctx`.
- [x] `black --check .` → clean.

## Test plan

- [x] CI: reproducibility job green
- [x] CI: black format check green

## Design note: why `tile_cache` is a callable

The tile cache is a per-Dask-worker module-level singleton (`tile_cache._WORKER_CACHE`), initialised via `client.run(tile_cache.init_worker_cache, ...)` in the main process. Its lifetime is the worker process — it can't be carried inside a `ComputeContext` that gets pickled across workers. So `ctx.tile_cache` holds a *getter* (`tile_cache.get_worker_cache` by default, or any stub a test wants to inject); the cache resolves at call time on the worker that owns it.

## Phase B sequence

Third PR (#35, logging cleanup) and fourth (#36, var.py split) next.
