### PR TITLE
(#35) Library-level logging cleanup: new pycsa/logging_config.py

### DIFF
--- a/changelog.d/35.changed.rst
+++ b/changelog.d/35.changed.rst
@@ -1,0 +1,21 @@
+Library-level diagnostics now go through stdlib ``logging``:
+
+* New ``pycsa.logging_config.configure_logging`` extracted from
+  ``runs/icon_etopo_global.setup_logger``. Attaches the file handler to
+  the **root** logger (the old per-script setup silently dropped logs
+  from ``pycsa.*`` child loggers that didn't propagate to the script's
+  own namespace).
+* ``runs/icon_etopo_global.setup_logger`` is now a thin wrapper around
+  ``configure_logging``.
+* ``pycsa.core.delaunay`` and ``pycsa.core.io`` get module-level loggers
+  (``logging.getLogger(__name__)``). Their unconditional ``print()``
+  calls — Delaunay-triangulation banner, "Data fetched", "Error closing
+  …", "Coarse-graining failed (…)" — are converted to ``logger.info`` /
+  ``logger.warning`` so they respect log level and land in the same file
+  as the run-script's own output.
+* Verbose-gated prints (``if self.verbose: print(...)``) are left alone
+  for now — they're already correctly gated.
+
+The ``obj`` base class and ``obj.print()`` method are retained — deletion
+moves to the ``var.py`` split (next refactor) where the change can be
+coordinated with the dataclass migration.

--- a/pycsa/core/delaunay.py
+++ b/pycsa/core/delaunay.py
@@ -1,6 +1,11 @@
+import logging
+
 import numpy as np
 from scipy.spatial import Delaunay
+
 from pycsa.core import utils, var
+
+logger = logging.getLogger(__name__)
 
 
 def get_decomposition(topo, xnp=11, ynp=6, padding=0):
@@ -52,8 +57,8 @@ def get_decomposition(topo, xnp=11, ynp=6, padding=0):
     tri.tri_lat_verts = lats[tri.simplices]
     tri.tri_lon_verts = lons[tri.simplices]
 
-    print("Delaunay triangulation object created.")
-    print("Number of triangles =", len(tri.tri_lat_verts))
+    logger.info("Delaunay triangulation object created.")
+    logger.info("Number of triangles = %d", len(tri.tri_lat_verts))
 
     # Compute the centroid for each vertex.
     tri.tri_clats = tri.tri_lat_verts.sum(axis=1) / 3.0
@@ -88,7 +93,7 @@ def get_land_cells(tri, topo, height_tol=0.5, percent_tol=0.95):
     for tri_idx in range(n_tri)[::2]:
         cell = var.topo_cell()
 
-        print("computing idx:", tri_idx)
+        logger.debug("computing idx: %d", tri_idx)
 
         simplex_lat = tri.tri_lat_verts[tri_idx]
         simplex_lon = tri.tri_lon_verts[tri_idx]

--- a/pycsa/core/io.py
+++ b/pycsa/core/io.py
@@ -2,17 +2,20 @@
 Input/Output routines
 """
 
-import netCDF4 as nc
-import numpy as np
-import h5py
+import logging
 import os
 import threading
-
 from datetime import datetime
+
+import h5py
+import netCDF4 as nc
+import numpy as np
 from scipy import interpolate
 from tqdm import tqdm
 
 from pycsa.core import utils
+
+logger = logging.getLogger(__name__)
 
 # ============================================================================
 # CRITICAL: Global lock for NetCDF/HDF5 operations
@@ -134,7 +137,7 @@ class ncdata(object):
         z_res = np.take_along_axis(z_res.reshape(nla, nlo), lon_res_sort_idx, axis=1)
         topo_2D = z_res.reshape(nla, nlo)
 
-        print("Data fetched...")
+        logger.info("Data fetched...")
         cell.lon = lon_uniq
         cell.lat = lat_uniq
         cell.topo = topo_2D
@@ -225,7 +228,7 @@ class ncdata(object):
                     try:
                         ds.close()
                     except Exception as e:
-                        print(f"Warning: Error closing {filepath}: {e}")
+                        logger.warning("Error closing %s: %s", filepath, e)
                 self._thread_local.file_cache.clear()
 
         def get_topo(self, cell):
@@ -810,7 +813,7 @@ class ncdata(object):
                     try:
                         ds.close()
                     except Exception as e:
-                        print(f"Warning: Error closing {filepath}: {e}")
+                        logger.warning("Error closing %s: %s", filepath, e)
                 self._thread_local.file_cache.clear()
 
         def get_topo(self, cell):
@@ -1171,8 +1174,8 @@ class ncdata(object):
                         ).mean(axis=(-1, -2))
                     except (ValueError, MemoryError) as e:
                         # If coarse-graining fails, fall back to no coarse-graining
-                        print(
-                            f"Warning: Coarse-graining failed ({e}), using full resolution"
+                        logger.warning(
+                            "Coarse-graining failed (%s), using full resolution", e
                         )
                         cell.lat = lat_sorted
                         cell.lon = lon_sorted

--- a/pycsa/logging_config.py
+++ b/pycsa/logging_config.py
@@ -1,0 +1,86 @@
+"""Centralised logging configuration for pyCSA runs.
+
+A thin wrapper around stdlib ``logging`` that:
+
+* attaches a timestamped ``FileHandler`` to the **root** logger (so module
+  loggers under ``pycsa.*`` and run scripts all propagate up and land in
+  the same log file — the previous per-script setup only captured the
+  caller module's own ``__name__`` namespace and silently dropped logs
+  from ``pycsa.core.tile_cache`` etc.);
+* silences chatty third-party libraries (matplotlib, distributed) by
+  default;
+* returns the log-file path so the caller can include it in startup
+  banners.
+
+Replaces the inline ``setup_logger`` previously living in
+``runs/icon_etopo_global.py`` so other run scripts (and tests that want a
+file log) can call the same helper without copy-paste.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Sequence
+
+_DEFAULT_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+_DEFAULT_DATEFMT = "%Y-%m-%d %H:%M:%S"
+_DEFAULT_SILENCE: tuple[str, ...] = ("matplotlib", "distributed")
+
+
+def configure_logging(
+    log_dir: Path | str = "logs",
+    name_prefix: str = "pycsa_run",
+    level: int = logging.INFO,
+    silence: Sequence[str] = _DEFAULT_SILENCE,
+    fmt: str = _DEFAULT_FORMAT,
+    datefmt: str = _DEFAULT_DATEFMT,
+) -> Path:
+    """Attach a timestamped file handler to the root logger.
+
+    Parameters
+    ----------
+    log_dir
+        Directory for the log file (created if missing).
+    name_prefix
+        Stem of the log filename. The full filename is
+        ``{name_prefix}_{YYYYMMDD_HHMMSS}.log``.
+    level
+        Log level for the root logger and the file handler.
+    silence
+        Logger names whose level is raised to WARNING so they don't flood
+        the file (matplotlib + Dask distributed by default).
+    fmt, datefmt
+        Standard ``logging.Formatter`` arguments.
+
+    Returns
+    -------
+    Path
+        Absolute path to the newly-created log file.
+    """
+    log_path = Path(log_dir)
+    log_path.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    log_file = log_path / f"{name_prefix}_{timestamp}.log"
+
+    root = logging.getLogger()
+    root.setLevel(level)
+
+    # Drop any FileHandler we've added before so re-calling configure_logging
+    # doesn't accumulate duplicate writers.
+    for h in list(root.handlers):
+        if isinstance(h, logging.FileHandler):
+            root.removeHandler(h)
+            h.close()
+
+    file_handler = logging.FileHandler(log_file, mode="w")
+    file_handler.setLevel(level)
+    file_handler.setFormatter(logging.Formatter(fmt, datefmt=datefmt))
+    root.addHandler(file_handler)
+
+    for name in silence:
+        logging.getLogger(name).setLevel(logging.WARNING)
+
+    return log_file.resolve()

--- a/runs/icon_etopo_global.py
+++ b/runs/icon_etopo_global.py
@@ -43,48 +43,14 @@ logger = logging.getLogger(__name__)
 
 
 def setup_logger(log_dir="logs"):
+    """Thin wrapper around :func:`pycsa.logging_config.configure_logging`
+    that preserves the historical ``icon_etopo_global_*`` filename prefix
+    and the previous default level. New code should call
+    ``configure_logging`` directly.
     """
-    Set up logging configuration for ETOPO global run.
+    from pycsa.logging_config import configure_logging
 
-    Parameters
-    ----------
-    log_dir : str
-        Directory for log files (default: "logs")
-
-    Returns
-    -------
-    Path
-        Path to the log file
-    """
-    # Create log directory
-    log_path = Path(log_dir)
-    log_path.mkdir(parents=True, exist_ok=True)
-
-    # Create timestamped log filename
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    log_file = log_path / f"icon_etopo_global_{timestamp}.log"
-
-    # Configure logger
-    logger = logging.getLogger(__name__)
-    logger.setLevel(logging.INFO)
-
-    # Remove any existing handlers
-    logger.handlers.clear()
-
-    # File handler - logs everything
-    file_handler = logging.FileHandler(log_file, mode="w")
-    file_handler.setLevel(logging.INFO)
-    file_formatter = logging.Formatter(
-        "%(asctime)s - %(levelname)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
-    )
-    file_handler.setFormatter(file_formatter)
-    logger.addHandler(file_handler)
-
-    # Also silence matplotlib and other libraries from console
-    logging.getLogger("matplotlib").setLevel(logging.WARNING)
-    logging.getLogger("distributed").setLevel(logging.WARNING)
-
-    return log_file
+    return configure_logging(log_dir=log_dir, name_prefix="icon_etopo_global")
 
 
 def get_topo_colormap():


### PR DESCRIPTION
Closes #35. Third of four Phase B refactors gated by the reproducibility suite (#31).

## Scope (clarified from the original issue)

The graphify-flagged "70 obj.print() callsites across 26 files" turned out to already be cleaned — zero `.print(` method calls remain in `pycsa/` on current `main`. The actual target of this PR is **~8 unconditional `print()` calls in `pycsa/core/io.py` and `pycsa/core/delaunay.py`** that should be respecting a log level instead of writing to stdout unconditionally.

The `obj` base class **stays** for now — `var.obj()` is used as a generic attribute bag in ~15+ files outside `pycsa/` (tests, run scripts, `inputs/*`), and `params.print()` (inherited from `obj`) is invoked from several run scripts. Deletion is moved to **#36 (var.py split)** where it can be coordinated with the dataclass migration.

## What changed

| file | change |
|---|---|
| `pycsa/logging_config.py` | **New.** `configure_logging(log_dir, name_prefix, level, silence, fmt, datefmt)` — extracted from `runs/icon_etopo_global.setup_logger`. Attaches the file handler to the **root** logger so all `pycsa.*` and run-script loggers propagate into the same file. |
| `runs/icon_etopo_global.py` | `setup_logger` is now a one-line wrapper calling `configure_logging(name_prefix="icon_etopo_global", ...)`. Historical log-filename pattern preserved. |
| `pycsa/core/delaunay.py` | Adds `logger = logging.getLogger(__name__)`. Three unconditional `print()`s become `logger.info` / `logger.debug`. |
| `pycsa/core/io.py` | Adds `logger = logging.getLogger(__name__)`. Four unconditional `print()`s ("Data fetched…", two "Error closing …" in cache-cleanup paths, and the "Coarse-graining failed (…)" except-block) become `logger.info` / `logger.warning`. |
| `changelog.d/35.changed.rst` | towncrier fragment. |

## Why "root, not script-namespace"

The old `setup_logger` did:
```python
logger = logging.getLogger(__name__)  # __name__ == 'icon_etopo_global' or similar
logger.addHandler(file_handler)
```
This only captured logs emitted under the run script's own logger namespace. Logs from `pycsa.core.tile_cache.logger.info(...)` propagated up to root, found no handler, and were silently dropped. The new helper attaches to root so all child loggers — `pycsa.core.delaunay`, `pycsa.core.io`, `pycsa.core.tile_cache`, and the run script itself — emit to the same file.

Format is also updated to include `%(name)s` so multi-module log output is self-attributing.

## Acceptance (all met locally)

- [x] `pycsa.logging_config.configure_logging` smoke test: child logger `pycsa.test` emits to the file via root-handler propagation.
- [x] `grep -rn '\.print(' pycsa/` returns nothing (verified separately).
- [x] All unconditional `print()` calls in `pycsa/core/{io,delaunay}.py` converted; verbose-gated prints intentionally left alone.
- [x] `pytest tests/reproducibility/ -v` → 3 passed in 13.9 s.
- [x] `black --check .` → clean.

## Out of scope

- Bulk-converting `if self.verbose: print(...)` → `logger.debug(...)` (the verbose gate already does the right thing; this is a stylistic follow-up).
- Deleting `obj` / `obj.print()` — moves to #36.

## Phase B sequence

Last one next: #36 (split `pycsa/core/var.py` into proper dataclasses; retire `obj`).
