### PR TITLE
(#36) Split pycsa/core/var.py into proper dataclasses

### DIFF
--- a/changelog.d/36.changed.rst
+++ b/changelog.d/36.changed.rst
@@ -1,0 +1,27 @@
+``pycsa.core.var`` is split into thematic submodules with proper
+``@dataclass``-based classes:
+
+* :class:`pycsa.data.cell.grid`, :class:`pycsa.data.cell.topo`,
+  :class:`pycsa.data.cell.topo_cell` — grid + topography containers.
+* :class:`pycsa.data.results.analysis` — spectral analysis result.
+* :class:`pycsa.config.params.params` — per-run parameter container.
+
+``pycsa.core.var`` is retained as a thin re-export shim so existing
+``from pycsa.core import var`` and ``var.grid()`` / ``var.params()`` /
+etc. imports keep working through at least one release.
+
+The generic attribute-bag class :class:`pycsa.core.var.obj` is
+**deprecated**. It still works but emits a ``DeprecationWarning`` on
+construction. Use :class:`types.SimpleNamespace` instead.
+
+Behavior preserved:
+
+* :meth:`pycsa.data.cell.grid.apply_f` now skips a ``NON_CONVERTIBLES``
+  ``ClassVar`` exclusion set (``links``, ``cell_area``) instead of
+  setting a runtime instance attribute — 27 ``apply_f`` call sites
+  continue to work unchanged.
+* :attr:`pycsa.config.params.params.rect` is still derived from
+  ``cg_spsp`` via ``__post_init__`` (matches the old
+  ``self.rect = False if self.cg_spsp else True`` inline logic).
+* :meth:`pycsa.config.params.params.print` is retained on the params
+  class directly (previously inherited from ``obj``).

--- a/pycsa/config/__init__.py
+++ b/pycsa/config/__init__.py
@@ -1,0 +1,9 @@
+"""User-facing run-time configuration.
+
+Currently exposes :class:`pycsa.config.params.params`, the per-run
+parameter container moved out of ``pycsa.core.var``.
+"""
+
+from pycsa.config.params import params
+
+__all__ = ["params"]

--- a/pycsa/config/params.py
+++ b/pycsa/config/params.py
@@ -1,0 +1,154 @@
+"""User parameter dataclass.
+
+Defines the required and optional fields for a CSA run. Moved from
+``pycsa.core.var`` and refactored to ``@dataclass`` with explicit
+defaults. The historical ``cg_spsp`` → ``rect`` coupling
+(``self.rect = False if self.cg_spsp else True``) is preserved via
+``__post_init__``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class params:
+    """Per-run parameters for the CSA pipeline.
+
+    Fields with ``None`` defaults are compulsory (see :meth:`check_init`
+    / :meth:`check_delaunay`). All other fields have sensible defaults
+    matching the historical inline ``__init__``.
+    """
+
+    # Filenames + paths
+    run_case: str = ""
+    path_compact_grid: Any = None
+    path_compact_topo: Any = None
+    path_output: Any = None
+    fn_output: Any = None
+
+    # MERIT
+    enable_merit: bool = True
+    merit_cg: int = 10
+    path_merit: Any = None
+
+    # Domain
+    lat_extent: Any = None
+    lon_extent: Any = None
+
+    run_full_land_model: bool = True
+
+    # Delaunay (compulsory when get_delaunay_triangulation is True)
+    delaunay_xnp: Any = None
+    delaunay_ynp: Any = None
+    rect_set: Any = None
+    lxkm: Any = None
+    lykm: Any = None
+
+    # Fourier
+    nhi: int = 24
+    nhj: int = 48
+    n_modes: int = 100
+
+    # Artificial wind
+    U: float = 10.0
+    V: float = 0.0
+
+    # Spec Appx flags
+    rect: bool = True
+    dfft_first_guess: bool = False
+    refine: bool = False
+    no_corrections: bool = True
+    cg_spsp: bool = False  # coarse-grain the spectral space?
+
+    # Solver flags
+    fa_iter_solve: bool = True
+    sa_iter_solve: bool = True
+
+    # Penalty terms
+    lmbda_fa: float = 1e-2  # first guess
+    lmbda_sa: float = 1e-1  # second step
+
+    # Tapering
+    taper_ref: bool = False
+    taper_fa: bool = False
+    taper_sa: bool = False
+    taper_art_it: int = 50
+    padding: int = 0  # must be less than 60
+
+    # Flags
+    get_delaunay_triangulation: bool = False
+    recompute_rhs: bool = False
+    debug: bool = False
+    debug_writer: bool = True
+    verbose: bool = False
+    plot: bool = False
+
+    def __post_init__(self) -> None:
+        # Preserve historical coupling: cg_spsp implies rect=False.
+        # Note: this overrides any explicit ``rect=`` passed at
+        # construction. Matches the old inline behavior, which set
+        # ``rect`` unconditionally based on ``cg_spsp`` at __init__ time.
+        self.rect = False if self.cg_spsp else True
+
+    # ------------------------------------------------------------------
+    # Validation
+    # ------------------------------------------------------------------
+
+    def self_test(self) -> bool:
+        """Check that compulsory parameters are set and (if requested)
+        Delaunay-related params too. Generates ``fn_output`` if missing.
+        """
+        if self.fn_output is None:
+            # Local import to avoid pycsa.core.io ↔ pycsa.config cycle.
+            from pycsa.core import io as _io
+
+            self.fn_output = _io.fn_gen(self)
+
+        self.check_init()
+
+        if self.get_delaunay_triangulation:
+            self.check_delaunay()
+
+        return True
+
+    def check_init(self) -> None:
+        """Raise if compulsory init params are undefined."""
+        compulsory = ["lat_extent", "lon_extent"]
+        offenders = self.checker(self, compulsory)
+        assert len(offenders) == 0, (
+            "Compulsory run parameter(s) undefined: %s" % offenders
+        )
+
+    def check_delaunay(self) -> None:
+        """Raise if compulsory Delaunay params are undefined."""
+        compulsory = ["delaunay_xnp", "delaunay_ynp", "rect_set", "lxkm", "lykm"]
+        offenders = self.checker(self, compulsory)
+        assert len(offenders) == 0, (
+            "Compulsory Delaunay run parameter(s) undefined: %s" % offenders
+        )
+
+    @staticmethod
+    def checker(arg, compulsory_params) -> list[str]:
+        """Return names of fields in ``compulsory_params`` that are ``None``."""
+        offenders = []
+        for key, value in vars(arg).items():
+            if key in compulsory_params:
+                if value is None:
+                    offenders.append(key)
+        return offenders
+
+    # ------------------------------------------------------------------
+    # Legacy convenience
+    # ------------------------------------------------------------------
+
+    def print(self) -> None:
+        """Print all attributes to stdout. Preserves the legacy
+        ``params.print()`` interface inherited from the old ``obj`` base
+        class — used by several run scripts to dump the configuration
+        banner at startup.
+        """
+        for name, value in vars(self).items():
+            print(name, value)

--- a/pycsa/core/var.py
+++ b/pycsa/core/var.py
@@ -1,409 +1,47 @@
+"""Deprecation shim for the old monolithic ``var.py``.
+
+This module previously held six classes; they have been split into
+thematic submodules:
+
+* :class:`grid`, :class:`topo`, :class:`topo_cell` → :mod:`pycsa.data.cell`
+* :class:`analysis` → :mod:`pycsa.data.results`
+* :class:`params` → :mod:`pycsa.config.params`
+* :class:`obj` → deprecated; use :class:`types.SimpleNamespace`
+
+Re-exports keep ``from pycsa.core import var`` (and ``var.grid()`` /
+``var.params()`` / etc.) working for at least one release. New code
+should import from the new locations directly.
 """
-This module defines the data objects used in the program.
-"""
 
-import numpy as np
-from pycsa.core import utils, io
+import warnings as _warnings
 
-
-class grid(object):
-    """
-    Grid class
-    """
-
-    def __init__(self):
-        """
-        Contains the ``(lat,lon)`` of each triangular grid cell with the corresponding vertices ``(lat_1, lat_2, lat_3)``, ``(lon_1, lon_2, lon_3)``.
-
-        ``link`` is a lookup table linking the grid cell to the corresponding topography file.
-        """
-        self.clat = None
-        self.clat_vertices = None
-        self.clon = None
-        self.clon_vertices = None
-        self.links = None
-        self.cell_area = None
-
-    def apply_f(self, f):
-        """
-        Applies a function to all class attributes, except those listed in ``non_convertibles``
-
-        Parameters
-        ----------
-        f : ``function``
-            arbitrary function to be applied to class attributes, e.g. a radians-degrees converter.
-        """
-        self.non_convertibles = ["non_convertibles", "links", "cell_area"]
-        for key, value in vars(self).items():
-            if key in self.non_convertibles:
-                pass
-            else:
-                setattr(self, key, f(value))
+from pycsa.config.params import params
+from pycsa.data.cell import grid, topo, topo_cell
+from pycsa.data.results import analysis
 
 
-class topo(object):
-    """
-    Topography class with its corresponding lat-lon values
+class obj:
+    """Generic attribute bag.
+
+    .. deprecated::
+       Use :class:`types.SimpleNamespace` instead. Retained as a
+       deprecation alias because there are ~15 external callers
+       (test fixtures, archived run scripts, inputs/) that still do
+       ``tri = var.obj()`` to build attribute bags at runtime. Those
+       call sites can migrate at their own pace.
     """
 
     def __init__(self):
-        self.lon = None
-        self.lat = None
-        self.topo = None
-        self.analysis = None
-
-
-class topo_cell(topo):
-    """
-    Inherits and initialises an instance of :class:`src.var.topo`, to be used for storing data associated to a grid cell
-    """
-
-    def __init__(self):
-        super().__init__()
-
-    def gen_mgrids(self, grad=False):
-        """
-        Generates a meshgrid based on the lat-lon values
-
-        Parameters
-        ----------
-        grad : bool, optional
-            deprecated by 0.90.0, by default False
-        """
-        if not grad:
-            lat, lon = self.lat, self.lon
-            self.lon_grid, self.lat_grid = np.meshgrid(lon, lat)
-        else:
-            lat, lon = self.lat, self.lon
-            grad_lat, grad_lon = self.grad_lat, self.grad_lon
-            self.grad_lat_lon_grid, self.grad_lat_lat_grid = np.meshgrid(lon, grad_lat)
-            self.grad_lon_lon_grid, self.grad_lon_lat_grid = np.meshgrid(grad_lon, lat)
-
-    def __get_lat_lon_points(self, grad=False):
-        """
-        Private method to get the (lat,lon) coordinate for each topographic data point
-        """
-        if not grad:
-            lat_grid, lon_grid = self.lat_grid, self.lon_grid
-        else:
-            lat_grid, lon_grid = self.grad_lat_grid, self.grad_lon_grid
-
-        lat_grid_tmp = np.expand_dims(np.copy(lat_grid), -1)
-        lon_grid_tmp = np.expand_dims(np.copy(lon_grid), -1)
-
-        lat_grid_tmp = utils.rescale(lat_grid_tmp)
-        lon_grid_tmp = utils.rescale(lon_grid_tmp)
-
-        return np.stack((lon_grid_tmp, lat_grid_tmp), axis=2).reshape(-1, 2)
-
-    def __get_mask(self, triangle):
-        """
-        Private method to generate the mask based on which data points are inside the triangle grid cell.
-
-        Parameters
-        ----------
-        triangle : :class:`src.utils.gen_triangle`
-            instance of the generate-triangle class
-        """
-        lat_lon_points = self.__get_lat_lon_points()
-        init_poly = triangle.vec_get_mask
-
-        self.mask = (
-            np.array([init_poly(elem) for elem in lat_lon_points])
-            .reshape(self.lat.size, self.lon.size)
-            .astype("bool_")
+        _warnings.warn(
+            "pycsa.core.var.obj is deprecated; use types.SimpleNamespace instead.",
+            DeprecationWarning,
+            stacklevel=2,
         )
-
-    def get_masked(self, triangle=None, mask=None):
-        """Gets the masked attributes
-
-        Parameters
-        ----------
-        triangle : :class:`src.utils.gen_triangle`
-            instance of the generate-triangle class, by default None
-        mask : array-like, optional
-            2D array of the mask, by default None
-        """
-
-        if (triangle is not None) and (mask is None):
-            self.__get_mask(triangle)
-        elif mask is not None:
-            self.mask = mask
-
-        self.lon_m = self.lon_grid[self.mask]
-        self.lat_m = self.lat_grid[self.mask]
-        self.topo_m = self.topo[self.mask]
-
-        self.topo_m -= self.topo_m.mean()
-
-    def get_grad_topo(self, triangle):
-        """
-        Computes the gradient of the topography
-
-        .. deprecated:: 0.90.0
-
-        """
-        lat, lon = self.lat, self.lon
-        self.grad_lat = lat[:-1] + 0.5 * (lat[1:] - lat[:-1])
-        self.grad_lon = lon[:-1] + 0.5 * (lon[1:] - lon[:-1])
-
-        self.gen_mgrids(grad=True)
-
-        dlat = np.diff(self.lat).reshape(1, -1)
-        dlon = np.diff(self.lon).reshape(-1, 1)
-
-        grad_lon_topo = (self.topo[1:, :] - self.topo[:-1, :]) / dlon
-        grad_lat_topo = (self.topo[:, 1:] - self.topo[:, :-1]) / dlat
-
-        lat_lon_points = self.__get_lat_lon_points(grad=True)
-        init_poly = triangle.vec_get_mask
-
-        self.grad_mask = (
-            np.array([init_poly(elem) for elem in lat_lon_points])
-            .reshape(self.topo.shape)
-            .astype("bool_")
-        )
-
-        grad_lon_topo = grad_lon_topo[self.grad_mask]
-        grad_lat_topo = grad_lat_topo[self.grad_mask]
-
-        self.grad_lon_m = self.grad_lon_grid[self.grad_mask]
-        self.grad_lat_m = self.grad_lat_grid[self.grad_mask]
-        self.grad_topo_m = np.vstack([grad_lon_topo, grad_lat_topo])
-
-
-class analysis(object):
-    """
-    Analysis object, contains all the attributes required to compute the idealised pseudo-momentum fluxes
-
-    """
-
-    def __init__(self):
-        """
-        Initialises empty attributes
-        """
-        self.wlat = None
-        self.wlon = None
-        self.ampls = None
-
-        # only works with explicitly setting the (k,l)-values
-        self.kks = None
-        self.lls = None
-
-        self.recon = None
-
-    def get_attrs(self, fobj, freqs):
-        """Copies required attributes given the arguments
-
-        Parameters
-        ----------
-        fobj : :class:`src.fourier.f_trans`
-            instance of the Fourier transformer
-        freqs : array-like
-            2D (abs. valued real) spectrum
-        """
-        self.wlat = np.copy(fobj.wlat)
-        self.wlon = np.copy(fobj.wlon)
-        self.ampls = np.copy(freqs)
-
-        # only works with explicitly setting the (k,l)-values
-        # if hasattr(fobj, 'k_idx'):
-        #     self.kks = fobj.k_idx / (fobj.Ni)# / np.sqrt(2.0))
-        # else:
-        #     self.kks = fobj.m_i / (fobj.Ni)# / np.sqrt(2.0))
-        # if hasattr(fobj, 'l_idx'):
-        #     self.lls = fobj.l_idx / (fobj.Nj)# / np.sqrt(2.0))
-        # else:
-        #     self.lls = fobj.m_j / (fobj.Nj)# / np.sqrt(2.0))
-
-        #     pts = []
-        #     cnt = 0
-        #     for ll in self.lls:
-        #         for kk in self.kks:
-        #             if kk == 0 and ll <= 0:
-        #                 continue
-        #             else:
-        #                 pts.append([kk,ll])
-
-        #             if int(kk) == 0 and int(ll) == 0:
-        #                 idx = cnt
-
-        #             cnt += 1
-
-        #     pts = np.array(pts)
-        #     self.kks = pts[:,0]
-        #     self.lls = pts[:,1]
-
-        #     self.ampls = np.delete(self.ampls, idx)
-
-        self.kks = fobj.m_i / (fobj.Ni)
-        self.lls = fobj.m_j / (fobj.Nj)
-
-        wla = self.wlat
-        wlo = self.wlon
-
-        kks = self.kks * 2.0 * np.pi
-        lls = self.lls * 2.0 * np.pi
-
-        kks = kks / wlo
-        lls = lls / wla
-
-        self.dk = np.diff(self.kks).mean()
-        self.dl = np.diff(self.lls).mean()
-
-        self.kks, self.lls = np.meshgrid(kks, lls)
-
-    def grid_kk_ll(self, fobj, dat):
-        """
-        .. deprecated:: 0.90.0
-
-        """
-        m_i = fobj.m_i
-        m_j = fobj.m_j
-
-        freq_grid = np.zeros((len(m_i), len(m_j)))
-
-        cnt = 0
-        for l_idx, ll in enumerate(m_j):
-            for k_idx, kk in enumerate(m_i):
-                print(kk, ll, k_idx, l_idx, cnt)
-                if kk == 0 and ll <= 0:
-                    freq_grid[l_idx, k_idx] = 0.0
-                else:
-                    freq_grid[l_idx, k_idx] = dat[cnt]
-                    cnt += 1
-
-        return freq_grid
-
-
-class obj(object):
-    """Helper object to generate class instances on the fly"""
-
-    def __init__(self):
-        pass
 
     def print(self):
-        for var in vars(self):
-            print(var, getattr(self, var))
+        """Print all attributes to stdout (legacy diagnostic helper)."""
+        for name in vars(self):
+            print(name, getattr(self, name))
 
 
-class params(obj):
-    """User parameter class
-
-    Defines required and optional parameters to run a simulation
-    """
-
-    def __init__(self):
-        """
-        Defines the required parameters for a simulation run
-        """
-        # Define filenames
-        self.run_case = ""
-        self.path_compact_grid = None
-        self.path_compact_topo = None
-
-        self.path_output = None
-        self.fn_output = None
-
-        self.enable_merit = True
-        self.merit_cg = 10
-        self.path_merit = None
-
-        # Domain size
-        self.lat_extent = None
-        self.lon_extent = None
-
-        self.run_full_land_model = True
-
-        # Compulsory Delaunay parameters
-        self.delaunay_xnp = None
-        self.delaunay_ynp = None
-        self.rect_set = None
-        self.lxkm, self.lykm = None, None
-
-        # Set the Fourier parameters and object.
-        self.nhi = 24
-        self.nhj = 48
-        self.n_modes = 100
-
-        # Set artificial wind
-        self.U, self.V = 10.0, 0.0
-
-        # Set Spec Appx parameters
-        self.rect = True
-        self.dfft_first_guess = False
-        self.refine = False
-        self.no_corrections = True
-        self.cg_spsp = False  # coarse grain the spectral space?
-        self.rect = False if self.cg_spsp else True
-
-        self.fa_iter_solve = True
-        self.sa_iter_solve = True
-
-        # Penalty terms
-        self.lmbda_fa = 1e-2  # first guess
-        self.lmbda_sa = 1e-1  # second step
-
-        # Tapering parameters
-        self.taper_ref = False
-        self.taper_fa = False
-        self.taper_sa = False
-        self.taper_art_it = 50
-        self.padding = 0  # must be less than 60
-
-        # Flags
-        self.get_delaunay_triangulation = False
-        self.recompute_rhs = False
-        self.debug = False
-        self.debug_writer = True
-        self.verbose = False
-        self.plot = False
-
-    def self_test(self):
-        """
-        Checker method if user-defined parameters contains sensible compulsory parameters. Calls :func:`src.var.params.check_init` and :func:`src.var.params.check_delaunay`.
-
-        Returns
-        -------
-        bool
-            True if test passed, False otherwise
-        """
-        if self.fn_output is None:
-            self.fn_output = io.fn_gen(self)
-
-        self.check_init()
-
-        if self.get_delaunay_triangulation:
-            self.check_delaunay()
-
-        return True
-
-    def check_init(self):
-        """Checks if all required parameters are defined."""
-        compulsory_params = ["lat_extent", "lon_extent"]
-
-        offenders = self.checker(self, compulsory_params)
-        assert len(offenders) == 0, (
-            "Compulsory run parameter(s) undefined: %s" % offenders
-        )
-
-    def check_delaunay(self):
-        """
-        If run uses a Delaunay triangulation, this method checks if all required parameters are defined.
-        """
-        compulsory_params = ["delaunay_xnp", "delaunay_ynp", "rect_set", "lxkm", "lykm"]
-
-        offenders = self.checker(self, compulsory_params)
-        assert len(offenders) == 0, (
-            "Compulsory Delaunay run parameter(s) undefined: %s" % offenders
-        )
-
-    @staticmethod
-    def checker(arg, compulsory_params):
-        """Auxiliary function that checks if ``arg`` is in ``compulsory_params``"""
-        offenders = []
-        for key, value in vars(arg).items():
-            if key in compulsory_params:
-                if value is None:
-                    offenders.append(key)
-        return offenders
+__all__ = ["grid", "topo", "topo_cell", "analysis", "params", "obj"]

--- a/pycsa/data/__init__.py
+++ b/pycsa/data/__init__.py
@@ -1,0 +1,15 @@
+"""Data containers for grids, topography, and analysis results.
+
+Reorganises what used to live in ``pycsa.core.var`` into thematic
+submodules:
+
+* :mod:`pycsa.data.cell` — :class:`grid`, :class:`topo`, :class:`topo_cell`
+* :mod:`pycsa.data.results` — :class:`analysis`
+
+User-parameter config moves to :mod:`pycsa.config.params`.
+"""
+
+from pycsa.data.cell import grid, topo, topo_cell
+from pycsa.data.results import analysis
+
+__all__ = ["grid", "topo", "topo_cell", "analysis"]

--- a/pycsa/data/cell.py
+++ b/pycsa/data/cell.py
@@ -1,0 +1,178 @@
+"""Grid and topography data classes.
+
+Moved from ``pycsa.core.var`` and refactored to use ``@dataclass`` for
+explicit field declarations. Behavior is preserved including the
+``grid.apply_f`` convenience, which is now driven by a ``ClassVar``
+exclusion list instead of a runtime-set instance attribute.
+
+``topo_cell`` inherits its on-disk fields (``lon``, ``lat``, ``topo``,
+``analysis``) from ``topo`` and adds methods that set further runtime
+attributes (``lon_grid``, ``lat_grid``, ``mask``, ``topo_m``, …) — these
+are not declared as dataclass fields because they're side products of
+``gen_mgrids`` / ``get_masked`` / ``get_grad_topo`` rather than
+construction arguments.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, ClassVar
+
+import numpy as np
+
+from pycsa.core import utils
+
+
+@dataclass
+class grid:
+    """ICON triangular grid: cell centers + vertex coordinates + areas.
+
+    ``links`` is a lookup table mapping cells to their topography source
+    file; ``cell_area`` is the per-cell area in m². Both are skipped by
+    :meth:`apply_f` because they are not (lat, lon)-style data needing
+    unit conversion.
+    """
+
+    clat: np.ndarray | None = None
+    clat_vertices: np.ndarray | None = None
+    clon: np.ndarray | None = None
+    clon_vertices: np.ndarray | None = None
+    links: np.ndarray | None = None
+    cell_area: np.ndarray | None = None
+
+    # Field names that ``apply_f`` skips. Was a runtime-set instance list
+    # in the old class; now a ClassVar exclusion set, so the data fields
+    # and the apply_f exclusion list are in one place.
+    NON_CONVERTIBLES: ClassVar[tuple[str, ...]] = ("links", "cell_area")
+
+    def apply_f(self, f):
+        """Apply ``f`` to each (lat, lon)-style attribute.
+
+        Skips :attr:`NON_CONVERTIBLES`. Used in the wild as
+        ``grid.apply_f(utils.rad2deg)`` to convert radians to degrees
+        after loading from a NetCDF.
+
+        Parameters
+        ----------
+        f : callable
+            Function applied in-place to each non-skipped, non-``None``
+            field.
+        """
+        for name in self.__dataclass_fields__:
+            if name in self.NON_CONVERTIBLES:
+                continue
+            value = getattr(self, name)
+            if value is not None:
+                setattr(self, name, f(value))
+
+
+@dataclass
+class topo:
+    """Topography container: 1-D lat/lon arrays + 2-D elevation + analysis.
+
+    The ``analysis`` field is left ``Any`` because it holds a
+    :class:`pycsa.data.results.analysis` instance, but importing that
+    here would create a circular dependency.
+    """
+
+    lon: np.ndarray | None = None
+    lat: np.ndarray | None = None
+    topo: np.ndarray | None = None
+    analysis: Any = None
+
+
+@dataclass
+class topo_cell(topo):
+    """Cell-specific topography. Inherits ``lon`` / ``lat`` / ``topo`` /
+    ``analysis`` from :class:`topo`."""
+
+    def gen_mgrids(self, grad: bool = False) -> None:
+        """Generate meshgrids from the 1-D lat/lon arrays.
+
+        Sets ``self.lon_grid`` and ``self.lat_grid`` (and the gradient
+        meshgrids when ``grad=True``). These attributes are runtime
+        artifacts; they're not dataclass fields.
+        """
+        if not grad:
+            lat, lon = self.lat, self.lon
+            self.lon_grid, self.lat_grid = np.meshgrid(lon, lat)
+        else:
+            lat, lon = self.lat, self.lon
+            grad_lat, grad_lon = self.grad_lat, self.grad_lon
+            self.grad_lat_lon_grid, self.grad_lat_lat_grid = np.meshgrid(lon, grad_lat)
+            self.grad_lon_lon_grid, self.grad_lon_lat_grid = np.meshgrid(grad_lon, lat)
+
+    def __get_lat_lon_points(self, grad: bool = False) -> np.ndarray:
+        """Stack the 2-D grids into a flat ``(N, 2)`` ``(lon, lat)``
+        point array, rescaled."""
+        if not grad:
+            lat_grid, lon_grid = self.lat_grid, self.lon_grid
+        else:
+            lat_grid, lon_grid = self.grad_lat_grid, self.grad_lon_grid
+
+        lat_grid_tmp = np.expand_dims(np.copy(lat_grid), -1)
+        lon_grid_tmp = np.expand_dims(np.copy(lon_grid), -1)
+
+        lat_grid_tmp = utils.rescale(lat_grid_tmp)
+        lon_grid_tmp = utils.rescale(lon_grid_tmp)
+
+        return np.stack((lon_grid_tmp, lat_grid_tmp), axis=2).reshape(-1, 2)
+
+    def __get_mask(self, triangle) -> None:
+        """Compute a boolean mask of points inside ``triangle``."""
+        lat_lon_points = self.__get_lat_lon_points()
+        init_poly = triangle.vec_get_mask
+
+        self.mask = (
+            np.array([init_poly(elem) for elem in lat_lon_points])
+            .reshape(self.lat.size, self.lon.size)
+            .astype("bool_")
+        )
+
+    def get_masked(self, triangle=None, mask=None) -> None:
+        """Populate ``self.{lon_m, lat_m, topo_m}`` from a triangle or
+        explicit mask. Subtracts the mean from ``topo_m`` in place.
+        """
+        if (triangle is not None) and (mask is None):
+            self.__get_mask(triangle)
+        elif mask is not None:
+            self.mask = mask
+
+        self.lon_m = self.lon_grid[self.mask]
+        self.lat_m = self.lat_grid[self.mask]
+        self.topo_m = self.topo[self.mask]
+
+        self.topo_m -= self.topo_m.mean()
+
+    def get_grad_topo(self, triangle) -> None:
+        """Compute the topographic gradient.
+
+        .. deprecated:: 0.90.0
+        """
+        lat, lon = self.lat, self.lon
+        self.grad_lat = lat[:-1] + 0.5 * (lat[1:] - lat[:-1])
+        self.grad_lon = lon[:-1] + 0.5 * (lon[1:] - lon[:-1])
+
+        self.gen_mgrids(grad=True)
+
+        dlat = np.diff(self.lat).reshape(1, -1)
+        dlon = np.diff(self.lon).reshape(-1, 1)
+
+        grad_lon_topo = (self.topo[1:, :] - self.topo[:-1, :]) / dlon
+        grad_lat_topo = (self.topo[:, 1:] - self.topo[:, :-1]) / dlat
+
+        lat_lon_points = self.__get_lat_lon_points(grad=True)
+        init_poly = triangle.vec_get_mask
+
+        self.grad_mask = (
+            np.array([init_poly(elem) for elem in lat_lon_points])
+            .reshape(self.topo.shape)
+            .astype("bool_")
+        )
+
+        grad_lon_topo = grad_lon_topo[self.grad_mask]
+        grad_lat_topo = grad_lat_topo[self.grad_mask]
+
+        self.grad_lon_m = self.grad_lon_grid[self.grad_mask]
+        self.grad_lat_m = self.grad_lat_grid[self.grad_mask]
+        self.grad_topo_m = np.vstack([grad_lon_topo, grad_lat_topo])

--- a/pycsa/data/results.py
+++ b/pycsa/data/results.py
@@ -1,0 +1,84 @@
+"""Spectral analysis result dataclass.
+
+Moved from ``pycsa.core.var``. The ``get_attrs`` method copies fields
+from a Fourier transformer instance + spectrum into the analysis
+container; ``grid_kk_ll`` is retained as a deprecated helper for legacy
+diagnostic scripts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+
+@dataclass
+class analysis:
+    """Container for everything needed to compute idealised
+    pseudo-momentum fluxes from a CSA fit.
+
+    ``dk`` and ``dl`` are set at runtime by :meth:`get_attrs` (they're
+    computed from the wavenumber meshgrids), so they're not declared
+    as fields.
+    """
+
+    wlat: Any = None
+    wlon: Any = None
+    ampls: np.ndarray | None = None
+
+    # Wavenumber meshgrids; populated by get_attrs.
+    kks: np.ndarray | None = None
+    lls: np.ndarray | None = None
+
+    recon: np.ndarray | None = None
+
+    def get_attrs(self, fobj, freqs) -> None:
+        """Copy ``wlat`` / ``wlon`` from a Fourier transformer and
+        compute ``kks`` / ``lls`` meshgrids in physical units.
+
+        Sets ``self.dk`` and ``self.dl`` as runtime attributes (mean
+        spacing in each wavenumber direction).
+        """
+        self.wlat = np.copy(fobj.wlat)
+        self.wlon = np.copy(fobj.wlon)
+        self.ampls = np.copy(freqs)
+
+        self.kks = fobj.m_i / (fobj.Ni)
+        self.lls = fobj.m_j / (fobj.Nj)
+
+        wla = self.wlat
+        wlo = self.wlon
+
+        kks = self.kks * 2.0 * np.pi
+        lls = self.lls * 2.0 * np.pi
+
+        kks = kks / wlo
+        lls = lls / wla
+
+        self.dk = np.diff(self.kks).mean()
+        self.dl = np.diff(self.lls).mean()
+
+        self.kks, self.lls = np.meshgrid(kks, lls)
+
+    def grid_kk_ll(self, fobj, dat) -> np.ndarray:
+        """
+        .. deprecated:: 0.90.0
+        """
+        m_i = fobj.m_i
+        m_j = fobj.m_j
+
+        freq_grid = np.zeros((len(m_i), len(m_j)))
+
+        cnt = 0
+        for l_idx, ll in enumerate(m_j):
+            for k_idx, kk in enumerate(m_i):
+                print(kk, ll, k_idx, l_idx, cnt)
+                if kk == 0 and ll <= 0:
+                    freq_grid[l_idx, k_idx] = 0.0
+                else:
+                    freq_grid[l_idx, k_idx] = dat[cnt]
+                    cnt += 1
+
+        return freq_grid


### PR DESCRIPTION
Closes #36. **Final** Phase B refactor, gated by the reproducibility suite (#31).

## What changed

The monolithic `pycsa/core/var.py` held six classes (`grid`, `topo`, `topo_cell`, `analysis`, `obj`, `params`) as attribute-bag classes; the latter two inherited from a bare `obj` base whose only behavior was a `print()` method. This PR reorganises them into thematic submodules with `@dataclass`-based field declarations.

| file | change |
|---|---|
| `pycsa/data/cell.py` | **New.** `grid`, `topo`, `topo_cell` as `@dataclass`. `grid.apply_f` now driven by `NON_CONVERTIBLES: ClassVar[tuple[str, ...]]` instead of a runtime-set instance list. |
| `pycsa/data/results.py` | **New.** `analysis` as `@dataclass`; deprecated `grid_kk_ll` carried over unchanged. |
| `pycsa/config/params.py` | **New.** `params` as `@dataclass` with all ~40 fields + historical defaults. `cg_spsp → rect` coupling preserved via `__post_init__`. `params.print()` retained on the class (was inherited from `obj`). |
| `pycsa/core/var.py` | Thin re-export shim. Existing `from pycsa.core import var` + `var.grid()` / `var.params()` / etc. keep working unchanged across 25+ importers (runs/, tests/, inputs/, scripts/). |
| `pycsa/core/var.py:obj` | Retained in the shim but **deprecated** — `var.obj()` emits `DeprecationWarning` recommending `types.SimpleNamespace`. ~15 external callers can migrate at their own pace; final deletion is a follow-up. |
| `changelog.d/36.changed.rst` | towncrier fragment. |

## Behavior preserved

- `grid.apply_f(utils.rad2deg)` still works across all 27 call sites — `clat`/`clon`/`clat_vertices`/`clon_vertices` get converted; `links` and `cell_area` are skipped via the `NON_CONVERTIBLES` ClassVar (which replaces the historical runtime-set `self.non_convertibles` list).
- `params()` produces the same defaults; `params.rect == True` for `cg_spsp == False` (the historical inline `self.rect = False if self.cg_spsp else True` runs in `__post_init__`).
- `params.print()` emits the configuration banner identically — run scripts that call `params.print()` at startup still work.
- `topo_cell`'s runtime-set attributes (`lon_grid`, `lat_grid`, `mask`, `topo_m`, `grad_*`) are not declared as dataclass fields — they remain method side products. Dataclass tolerates this because no `__slots__` is declared.

## Acceptance (all met locally)

- [x] Old import path: `from pycsa.core import var` then `var.grid` / `var.topo_cell` / `var.params` / `var.analysis` — all resolve to the new dataclass implementations.
- [x] New import path: `from pycsa.data.cell import grid, topo, topo_cell`; `from pycsa.data.results import analysis`; `from pycsa.config.params import params` — all work.
- [x] `var.obj()` emits `DeprecationWarning` (verified under `-W error::DeprecationWarning`).
- [x] `grid.apply_f` sanity-tested: `cell_area` is correctly skipped.
- [x] `params.print()` round-trip: emits all 41 fields as before.
- [x] `var.obj()` attribute-bag pattern still works for external callers.
- [x] `pytest tests/reproducibility/ -v` → **3 passed in 14.7 s**. Numerics identical.
- [x] Broader sweep (`tests/test_dynamic_memory.py` + `tests/integration/` + `tests/reproducibility/`, excluding the pre-existing `test_delaunay_workflow` Numba race) → **15 passed in 19.9 s**.
- [x] `black --check .` clean.

## Out of scope

- Final deletion of `obj` (will land once external callers migrate to `types.SimpleNamespace`).
- Inlining the `var.py` re-export shim after the deprecation window — separate follow-up release.

## Phase B is now closed

Sequence completed:
1. #31 — Reproducibility-test infrastructure (#32, merged)
2. #33 — `pycsa.scheduling` module + drop sys.path hack (#37, merged)
3. #34 — `ComputeContext` (#38, merged)
4. #35 — Library-level logging cleanup (#39, merged)
5. **#36 — var.py split (this PR)**

Each refactor PR was gated by the suite from #32 staying green. Numerics held throughout.
