### PR TITLE
(#41) Complete pyproject.toml metadata

### DIFF
--- a/changelog.d/41.added.rst
+++ b/changelog.d/41.added.rst
@@ -1,0 +1,5 @@
+``pyproject.toml`` ``[project]`` table now declares the metadata expected
+by JORS reviewers and ``pip show``: ``description``, ``readme``,
+``license``, ``requires-python`` (``>=3.10``), ``authors``,
+``maintainers``, ``keywords``, Trove ``classifiers``, and
+``[project.urls]`` (homepage, docs, repo, issues).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,38 @@
 [project]
 name = "pyCSA"
 version = "0.95.1"
+description = "Python package for spectral approximation methods applied to topographic analysis"
+readme = "README.md"
+license = { file = "LICENSE" }
+requires-python = ">=3.10"
+authors = [
+    { name = "Ray Chew", email = "chew@caltech.edu" },
+]
+maintainers = [
+    { name = "Ray Chew", email = "chew@caltech.edu" },
+]
+keywords = [
+    "spectral approximation",
+    "constrained spectral approximation",
+    "topography",
+    "subgrid orography",
+    "ICON",
+    "ETOPO",
+    "MERIT",
+    "gravity waves",
+    "atmospheric science",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Atmospheric Science",
+]
 
 dependencies = [
     "Cartopy==0.25.0",
@@ -22,6 +54,12 @@ test = [
     "pytest-cov>=4.0",
     "pyyaml>=6.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/ray-chew/pyCSA"
+Documentation = "https://ray-chew.github.io/pyCSA"
+Repository = "https://github.com/ray-chew/pyCSA"
+Issues = "https://github.com/ray-chew/pyCSA/issues"
 
 # Packaging
 [build-system]


### PR DESCRIPTION
Closes #41. First of seven Phase C publication-readiness PRs.

## What changed

`pyproject.toml` `[project]` table now includes everything `pip show` and JORS reviewers expect:

- `description` — one-sentence summary.
- `readme` — points at `README.md`.
- `license` — `{ file = "LICENSE" }`.
- `requires-python = ">=3.10"`.
- `authors` + `maintainers` — Ray Chew `<chew@caltech.edu>`.
- `keywords` — 9 entries naming ICON / ETOPO / MERIT + the science context.
- Trove `classifiers` — GPLv3+, Python 3.10/3.11/3.12, Atmospheric Science, Science/Research, Beta.
- `[project.urls]` — Homepage / Documentation / Repository / Issues.

Plus `changelog.d/41.added.rst` (towncrier).

## Verification

`pip install -e .` then `pip show pyCSA`:

```
Name: pyCSA
Version: 0.95.1
Summary: Python package for spectral approximation methods applied to topographic analysis
Home-page: https://github.com/ray-chew/pyCSA
Author-email: Ray Chew <chew@caltech.edu>
License: GNU GENERAL PUBLIC LICENSE [Version 3, …]
```

No code changes; reproducibility suite untouched (will pass in CI). No black-relevant changes (TOML).
