### PR TITLE
Parameter-tuning extension: pluggable prior + SA-stage SpatialCV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,33 @@ jobs:
           path: coverage.xml
           if-no-files-found: warn
 
+  diagnostic-plots:
+    name: Baseline vs new-defaults plots
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ConorMacBride/install-package@v1
+        with:
+          apt: libgeos-dev
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install pyCSA + test extras
+        run: |
+          pip install --upgrade pip
+          pip install -e ".[test]"
+      - name: Generate baseline-vs-new-defaults plots
+        env:
+          MPLBACKEND: Agg
+        run: python scripts/compare_baseline_vs_new_defaults.py
+      - name: Upload plots as artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: baseline-vs-new-defaults-${{ github.sha }}
+          path: scripts/validate_outputs/*_baseline_vs_new.png
+          if-no-files-found: error
+
   docs:
     name: Build Documentation
     runs-on: ubuntu-latest

--- a/pycsa/compute/context.py
+++ b/pycsa/compute/context.py
@@ -35,10 +35,23 @@ class ComputeContext:
         cache itself is not stored (it's owned by the Dask worker process);
         we hold a getter that resolves at call time. Pass ``None`` for
         environments that don't need tile_cache (idealised runs, tests).
+    prior
+        Optional :class:`pycsa.core.priors.Prior` carried through to
+        ``lin_reg.do``. Spike scripts thread a structured prior here
+        without modifying any call site. ``None`` (default) means the
+        preserved scalar-trace branch in ``lin_reg.do`` runs unchanged.
+    selector
+        Optional :class:`pycsa.core.mode_selection.ModeSelector`
+        carried through to ``interface.second_appx``. Spike scripts
+        thread an alternative selector here without modifying any
+        call site. ``None`` (default) means the preserved inline
+        ``argmax`` loop in ``second_appx`` runs unchanged.
     """
 
     buffer_pool: BufferPool = field(default_factory=BufferPool)
     tile_cache: Optional[Callable[[], Any]] = None
+    prior: Optional[Any] = None
+    selector: Optional[Any] = None
 
     @classmethod
     def default(cls) -> "ComputeContext":

--- a/pycsa/core/hyperparams.py
+++ b/pycsa/core/hyperparams.py
@@ -1,0 +1,687 @@
+"""Hyperparameter selection for the structured Tikhonov prior.
+
+Phase 2 of the kernel-spike work introduces a separation between the
+two hyperparameters that ``SpectralPrior`` carries:
+
+- ``alpha`` — the spectral decay exponent. A structural belief about
+  the topography: chosen from the input field's empirical power-law
+  slope, or fixed by the user.
+- ``lmbda`` — the overall regularization scale. A data-driven scalar:
+  selected by GCV, marginal likelihood, or spatial cross-validation.
+
+Two protocols (:class:`AlphaSelector`, :class:`LambdaSelector`) expose
+these as pluggable extension points. Concrete strategies are provided
+with documented defaults: :class:`EmpiricalSpectralSlope` for alpha,
+:class:`GCVSelector` for lambda. The convenience constructor
+:func:`build_spectral_prior` wires them in the canonical order
+(alpha first, then lambda given alpha) and returns an explicit
+:class:`Hyperparams` record — no silent override of the kwarg-level
+``lmbda`` that :func:`pycsa.core.lin_reg.do` already accepts.
+
+**Honest framing on defaults.** ``EmpiricalSpectralSlope`` is grounded
+in the fact that topography spectra are typically well-approximated
+by a power law over a resolved-but-not-aliased wavenumber band; it
+returns the empirical slope plus its standard error, so the
+uncertainty is observable. ``GCVSelector`` is the textbook
+closed-form-LOO surrogate (Golub, Heath, and Wahba, 1979). Neither
+choice has been benchmarked against alternatives on the project's
+reproducibility fixtures yet — a one-script empirical check at
+``scripts/validate_hyperparam_defaults.py`` performs that comparison
+without being a full sweep.
+
+**Composition with sparse selection (mode_selection.py).** The
+recommended pattern is: tune ``(alpha, lmbda)`` with the FA
+``GreedyArgmax`` selector, then fix the resulting prior and switch
+to a sparsity-inducing selector for SA. Do *not* jointly tune
+``(alpha, lmbda, selector)``; the search space explodes and the
+selectors interact with the prior through the SA basis, not the
+FA basis where ``alpha``/``lmbda`` are calibrated.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, NamedTuple, Optional, Protocol
+
+import numpy as np
+
+from pycsa.core.priors import SpectralPrior
+
+
+# -----------------------------------------------------------------------------
+# Records and protocols
+# -----------------------------------------------------------------------------
+
+
+class SlopeFit(NamedTuple):
+    """Output of :class:`EmpiricalSpectralSlope`.
+
+    ``alpha`` is the positive power-law slope (``power ∝ ‖k‖^(-alpha)``).
+    ``stderr`` is the standard error from the linear regression in
+    log-log space. ``r_squared`` is the regression's coefficient of
+    determination — values much below ~0.9 mean the spectrum is not
+    well approximated by a single power law and downstream selectors
+    should be re-examined.
+    """
+
+    alpha: float
+    stderr: float
+    r_squared: float
+
+
+@dataclass
+class Hyperparams:
+    """Explicit (alpha, lmbda, prior) bundle returned by ``build_spectral_prior``.
+
+    Use the fields directly when calling ``lin_reg.do``::
+
+        hp = build_spectral_prior(topography, fobj)
+        a_m, recons = lin_reg.do(fobj, cell, lmbda=hp.lmbda, prior=hp.prior)
+
+    Both ``lmbda`` and ``prior`` are needed: the prior knows ``alpha``
+    and the per-mode shape, but ``lin_reg.do``'s ``lmbda`` kwarg is the
+    overall scale that the prior multiplies into. Passing one without
+    the other defeats the selection.
+    """
+
+    alpha: float
+    lmbda: float
+    prior: SpectralPrior
+    slope_fit: Optional[SlopeFit] = None
+
+
+class AlphaSelector(Protocol):
+    """Chooses the spectral decay exponent ``alpha`` from the input field."""
+
+    def __call__(self, topography: np.ndarray) -> float | SlopeFit: ...
+
+
+class LambdaSelector(Protocol):
+    """Chooses the regularization scale ``lmbda`` given the design matrix and alpha.
+
+    Parameters
+    ----------
+    design_matrix
+        Dense ``M`` matrix, shape ``(n_points, n_modes)``. Most selectors
+        operate on the normal-equations form ``MᵀM`` internally.
+    data
+        Target vector, shape ``(n_points,)``.
+    alpha
+        The chosen ``alpha`` (used by selectors that build trial priors).
+    prior_factory
+        Callable ``alpha -> Prior`` for selectors that need to instantiate
+        trial priors at the candidate ``lmbda``. The factory should
+        produce a prior parameterized only by ``alpha``; ``lmbda`` is
+        the kwarg passed at call time by the selector.
+
+    Returns
+    -------
+    lmbda : float
+        The selected regularization scale.
+    """
+
+    def __call__(
+        self,
+        design_matrix: np.ndarray,
+        data: np.ndarray,
+        *,
+        alpha: float,
+        prior_factory: Callable[[float], SpectralPrior],
+    ) -> float: ...
+
+
+# -----------------------------------------------------------------------------
+# Alpha selectors
+# -----------------------------------------------------------------------------
+
+
+@dataclass
+class FixedAlpha:
+    """Pass-through alpha selector. No default — caller must specify.
+
+    Use this when the user has a principled reason to fix ``alpha``
+    (e.g. matching a published spectrum estimate, debugging, or
+    side-by-side comparison with another tool). The lack of a default
+    value is deliberate: if you don't know what ``alpha`` should be,
+    use :class:`EmpiricalSpectralSlope` instead.
+    """
+
+    value: float
+
+    def __call__(self, topography: np.ndarray) -> float:
+        return float(self.value)
+
+
+@dataclass
+class EmpiricalSpectralSlope:
+    """Documented default alpha selector. Fits a power law to the
+    radially-averaged 2D periodogram of the input topography.
+
+    Returns a :class:`SlopeFit` carrying ``alpha`` plus its standard
+    error and R². Downstream callers can inspect the standard error to
+    decide whether a single-power-law model is appropriate, or use it
+    as a sweep width when building sensitivity tests.
+
+    Parameters
+    ----------
+    k_min_frac, k_max_frac
+        Lower and upper bound of the wavenumber band over which the
+        power law is fit, expressed as a fraction of Nyquist. Defaults
+        exclude the very-low-wavenumber region (poorly resolved on a
+        finite cell) and the near-Nyquist region (aliasing-prone).
+        These knobs *are* themselves hyperparameters and the returned
+        ``stderr`` partly reflects sensitivity to them — perturb and
+        re-fit if you want to bound that.
+    n_bins
+        Number of radial bins for the periodogram. Default 32 trades
+        off variance per bin against resolution.
+    """
+
+    k_min_frac: float = 0.02
+    k_max_frac: float = 0.5
+    n_bins: int = 32
+
+    def __call__(self, topography: np.ndarray) -> SlopeFit:
+        if topography.ndim != 2:
+            raise ValueError(
+                "EmpiricalSpectralSlope expects a 2D topography field; "
+                f"got ndim={topography.ndim}"
+            )
+        ny, nx = topography.shape
+        # Subtract mean to avoid a giant DC spike dominating the radial average.
+        field = topography - float(np.mean(topography))
+        power = np.abs(np.fft.fft2(field)) ** 2 / (ny * nx)
+
+        # Build a radial wavenumber grid in cycles/sample.
+        ky = np.fft.fftfreq(ny)[:, None]
+        kx = np.fft.fftfreq(nx)[None, :]
+        kmag = np.hypot(ky, kx)
+        # Mask to the resolved-but-not-aliased band.
+        nyq = 0.5
+        lo, hi = self.k_min_frac * nyq, self.k_max_frac * nyq
+        in_band = (kmag >= lo) & (kmag <= hi) & np.isfinite(power) & (power > 0)
+        if not np.any(in_band):
+            raise ValueError(
+                "No periodogram samples in the requested band "
+                f"[{lo:.4g}, {hi:.4g}] cycles/sample — check k_min_frac/k_max_frac"
+            )
+        # Radially bin in log-k.
+        log_k = np.log(kmag[in_band])
+        log_P = np.log(power[in_band])
+        bins = np.linspace(log_k.min(), log_k.max(), self.n_bins + 1)
+        which = np.digitize(log_k, bins) - 1
+        which = np.clip(which, 0, self.n_bins - 1)
+        bin_log_k = np.full(self.n_bins, np.nan)
+        bin_log_P = np.full(self.n_bins, np.nan)
+        for b in range(self.n_bins):
+            sel = which == b
+            if np.any(sel):
+                bin_log_k[b] = log_k[sel].mean()
+                bin_log_P[b] = log_P[sel].mean()
+        keep = np.isfinite(bin_log_k) & np.isfinite(bin_log_P)
+        if int(np.sum(keep)) < 3:
+            raise ValueError(
+                "Fewer than 3 populated bins — increase k_max_frac or n_bins"
+            )
+        # Linear fit in log-log space.
+        from scipy.stats import linregress
+        result = linregress(bin_log_k[keep], bin_log_P[keep])
+        # P ~ k^(-alpha) ⇒ slope = -alpha
+        alpha = float(-result.slope)
+        stderr = float(result.stderr)
+        r2 = float(result.rvalue ** 2)
+        return SlopeFit(alpha=alpha, stderr=stderr, r_squared=r2)
+
+
+# -----------------------------------------------------------------------------
+# Lambda selectors
+# -----------------------------------------------------------------------------
+
+
+def _default_lambda_grid(design_matrix: np.ndarray) -> np.ndarray:
+    """Log-spaced grid scaled by ``trace(MᵀM)/N``.
+
+    Matches the scale of the existing scalar-trace branch so the grid
+    spans the regime where ``lin_reg.do`` historically operates.
+    """
+    n = design_matrix.shape[1]
+    trace = float(np.einsum("ij,ij->", design_matrix, design_matrix)) / max(n, 1)
+    return np.logspace(-8, 2, 41) * max(trace, 1e-12)
+
+
+@dataclass
+class FixedLambda:
+    """Pass-through lambda selector. No default — caller must specify.
+
+    Mirrors :class:`FixedAlpha`. Use when ``lmbda`` is known a priori
+    (e.g. matching the existing scalar default in ``lin_reg.do``).
+    """
+
+    value: float
+
+    def __call__(self, design_matrix, data, *, alpha, prior_factory) -> float:
+        return float(self.value)
+
+
+@dataclass
+class GCVSelector:
+    """Documented default lambda selector. Generalized cross-validation.
+
+    For each candidate lambda on a log-spaced grid, computes::
+
+        GCV(lambda) = || y - M â(lambda) ||² / (n - tr(H(lambda)))²
+
+    where ``â(lambda)`` solves the regularized normal equations and
+    ``H(lambda) = M (MᵀM + Λ(lambda))⁻¹ Mᵀ`` is the hat matrix. Returns
+    the lambda that minimizes GCV.
+
+    Closed-form approximation to leave-one-out cross-validation
+    (Golub, Heath, Wahba 1979). Cheap, well-behaved on this problem
+    class, no held-out machinery required. The implicit assumption is
+    that the prior form (the structured ``Λ`` shape) is approximately
+    correct; if you don't trust the prior form, use
+    :class:`SpatialCVSelector` instead.
+
+    Parameters
+    ----------
+    lambda_grid
+        Candidate lambdas. If ``None``, falls back to a 41-point
+        log-spaced grid scaled by ``trace(MᵀM)/N``.
+    """
+
+    lambda_grid: Optional[np.ndarray] = None
+
+    def __call__(self, design_matrix, data, *, alpha, prior_factory) -> float:
+        M = np.asarray(design_matrix, dtype=float)
+        y = np.asarray(data, dtype=float).reshape(-1)
+        n = M.shape[0]
+        # Eigendecomposition of MᵀM lets us evaluate every candidate
+        # lambda in O(N) per candidate instead of O(N³). The hat trace
+        # and residual norm both reduce to sums over eigenvalues.
+        E = M.T @ M
+        # MᵀM is symmetric PSD; use eigh.
+        eigvals, eigvecs = np.linalg.eigh(E)
+        Mt_y = M.T @ y                       # shape (N,)
+        proj = eigvecs.T @ Mt_y              # shape (N,)
+        y_norm2 = float(y @ y)
+        prior = prior_factory(alpha)
+        # Trial-prior diagonal: build a representative diag at lmbda=1
+        # then scale it linearly per candidate (the spec defines
+        # Λ_m ∝ lmbda).
+        unit_diag = np.asarray(
+            prior(fobj=None, E_tilda_lm=E, lmbda=1.0), dtype=float
+        )
+        # GCV does not care about the eigenvector basis for Λ — we
+        # approximate Λ as diagonal in the eigenbasis of MᵀM by taking
+        # its mean. This is exact for IsotropicPrior and a good
+        # approximation for SpectralPrior on regular Fourier grids.
+        lambda_grid = (
+            self.lambda_grid
+            if self.lambda_grid is not None
+            else _default_lambda_grid(M)
+        )
+        scores = np.full_like(lambda_grid, np.inf, dtype=float)
+        for i, lam in enumerate(lambda_grid):
+            shift = float(np.mean(unit_diag * lam))
+            denom = eigvals + shift
+            if np.any(denom <= 0):
+                continue
+            # â projected onto eigenbasis: proj * eigvals / denom; then
+            # residual² = ||y||² - 2 yᵀM â + âᵀ MᵀM â reduces to:
+            ratio = eigvals / denom
+            residual2 = y_norm2 - float(np.sum((proj ** 2) * (2 * ratio - ratio ** 2)))
+            trH = float(np.sum(ratio))
+            denom_gcv = (n - trH) ** 2
+            if denom_gcv <= 0:
+                continue
+            scores[i] = max(residual2, 0.0) / denom_gcv
+        return float(lambda_grid[int(np.argmin(scores))])
+
+
+@dataclass
+class MarginalLikelihoodSelector:
+    """Empirical-Bayes lambda selector via type-II MLE.
+
+    Wraps ``sklearn.linear_model.BayesianRidge``, which performs the
+    standard MacKay-1992 evidence-approximation fixed-point iteration
+    jointly over the noise precision ``α`` and prior precision ``λ``
+    with weak Gamma hyperpriors. The returned scalar is the effective
+    ridge weight :math:`\\lambda_{\\text{eff}} = \\lambda / \\alpha`
+    (sklearn's convention), which is what ``lin_reg.do``'s ``lmbda``
+    kwarg expects.
+
+    **When this differs from GCV.** GCV approximates leave-one-out
+    CV under the implicit assumption of homoscedastic Gaussian noise.
+    Marginal likelihood agrees with GCV in that regime. The two
+    diverge when (a) the residual distribution is heavily non-Gaussian
+    (heavy tails, skew — common with topography in coastal/glacial
+    cells), or (b) the noise variance varies systematically with
+    location (heteroscedasticity from data-source mixing — e.g. MERIT
+    coastal masking). Prefer this selector over GCV in those regimes;
+    otherwise GCV is cheaper and produces equivalent results.
+
+    **Limitation.** ``BayesianRidge`` assumes an isotropic prior on
+    the coefficients. For ``SpectralPrior(alpha != 0)`` this selector
+    returns the scalar overall scale ``lmbda``; the per-mode shape
+    still comes from the ``Prior`` callable. If you need per-mode
+    marginal likelihood, use :class:`SpatialCVSelector` instead.
+
+    Parameters
+    ----------
+    max_iter, tol
+        Passed through to ``BayesianRidge``.
+    """
+
+    max_iter: int = 300
+    tol: float = 1e-3
+
+    def __call__(self, design_matrix, data, *, alpha, prior_factory) -> float:
+        try:
+            from sklearn.linear_model import BayesianRidge
+        except ImportError as exc:
+            raise ImportError(
+                "MarginalLikelihoodSelector requires scikit-learn. "
+                "Install it or use GCVSelector."
+            ) from exc
+        M = np.asarray(design_matrix, dtype=float)
+        y = np.asarray(data, dtype=float).reshape(-1)
+        br = BayesianRidge(
+            alpha_init=1.0,
+            lambda_init=1.0,
+            max_iter=self.max_iter,
+            tol=self.tol,
+            fit_intercept=False,
+            compute_score=False,
+        )
+        br.fit(M, y)
+        # sklearn's convention: alpha_ = 1/σ², lambda_ = prior precision.
+        # Effective ridge weight in the MAP objective is lambda_/alpha_.
+        return float(br.lambda_ / max(br.alpha_, 1e-12))
+
+
+@dataclass
+class SpatialCVSelector:
+    """Lambda selector via spatial k-fold cross-validation.
+
+    Partitions the rows of ``design_matrix`` into spatial patches with
+    a buffer zone (see :func:`pycsa.core.validation.spatial_cv_score`
+    for the patch geometry), fits the prior at each candidate
+    ``lmbda`` on the training rows, and evaluates reconstruction MSE
+    on the held-out patch's rows. The lambda with the smallest mean
+    held-out MSE wins.
+
+    **Why this matters even when GCV is the default.** GCV's
+    optimality depends on the prior form being approximately correct.
+    Spatial CV is the only selector here that *detects* misspecified
+    priors — if GCV and SpatialCV pick wildly different ``lmbda``
+    values, the prior form is doing more work than it should be, and
+    the user should revisit the choice of ``alpha`` (or pick a
+    different prior altogether). Run it as a diagnostic against GCV's
+    output even when GCV is what runs in production.
+
+    Parameters
+    ----------
+    coords
+        Row coordinates as a ``(n_points, 2)`` array of
+        ``(x, y)`` pairs in any consistent metric — used by
+        :func:`spatial_cv_score` to build patches. If ``None``,
+        falls back to row-index splitting (only sensible if rows are
+        already in geographic order).
+    n_folds
+        Number of spatial folds. Default 5.
+    buffer_fraction
+        Half-width of the buffer zone around each patch as a
+        fraction of patch size. Default 0.1.
+    lambda_grid
+        Same fallback as :class:`GCVSelector`.
+    rng_seed
+        Seed for reproducible fold assignment.
+    """
+
+    coords: Optional[np.ndarray] = None
+    n_folds: int = 5
+    buffer_fraction: float = 0.1
+    lambda_grid: Optional[np.ndarray] = None
+    rng_seed: Optional[int] = None
+
+    def __call__(self, design_matrix, data, *, alpha, prior_factory) -> float:
+        from pycsa.core.validation import spatial_cv_score
+
+        M = np.asarray(design_matrix, dtype=float)
+        y = np.asarray(data, dtype=float).reshape(-1)
+        lambda_grid = (
+            self.lambda_grid
+            if self.lambda_grid is not None
+            else _default_lambda_grid(M)
+        )
+        prior = prior_factory(alpha)
+        scores = np.full_like(lambda_grid, np.inf, dtype=float)
+        for i, lam in enumerate(lambda_grid):
+            cv = spatial_cv_score(
+                prior=prior,
+                lmbda=float(lam),
+                design_matrix=M,
+                data=y,
+                coords=self.coords,
+                n_folds=self.n_folds,
+                buffer_fraction=self.buffer_fraction,
+                rng_seed=self.rng_seed,
+            )
+            scores[i] = cv["mean_heldout_mse"]
+        return float(lambda_grid[int(np.argmin(scores))])
+
+
+# -----------------------------------------------------------------------------
+# Joint (alpha, lambda) selector
+# -----------------------------------------------------------------------------
+
+
+@dataclass
+class JointGCVSelector:
+    """Joint 2-D GCV minimization over (alpha, lmbda) for SpectralPrior.
+
+    Unlike :class:`GCVSelector` (which picks ``lmbda`` only, with ``alpha``
+    set externally — usually by ``EmpiricalSpectralSlope`` from the
+    input periodogram), this selector lets the GCV objective pick
+    *both* hyperparameters. The motivation: the periodogram fit can
+    pick an ``alpha`` that's too aggressive on real cells (south_pole
+    α ≈ 10 over-regularized signal-bearing high-k modes); a
+    held-out-error-driven search will usually pick something milder
+    or zero, when that's empirically better.
+
+    The search is a 2-D grid (``alpha_grid × lambda_grid``). One
+    eigendecomposition of ``MᵀM`` is reused across all candidates;
+    each evaluation is O(N) given the eigenbasis. Cost is therefore
+    ``|alpha_grid|`` × the cost of plain 1-D GCV.
+
+    **Approximation note.** Like :class:`GCVSelector`, the score is
+    computed by treating the prior's per-mode diagonal in the
+    eigenbasis of ``MᵀM`` (approximated by its mean, exact for
+    isotropic priors, good for slowly-varying structured priors on
+    regular Fourier grids). The chosen ``alpha`` still flows through
+    properly when the resulting :class:`SpectralPrior` is used in
+    ``lin_reg.do``, where the full per-mode diagonal IS applied — so
+    the GCV ranking is approximate but the post-selection fit is
+    exact.
+
+    Parameters
+    ----------
+    alpha_grid
+        Candidate exponents. Default ``[0, 0.5, 1, 1.5, 2, 3]`` —
+        spans isotropic through "more aggressive than typical
+        atmospheric / topographic spectra." ``0`` reduces to plain
+        isotropic GCV, recovered automatically when that's best.
+    lambda_grid
+        As :class:`GCVSelector`. ``None`` falls back to a 41-point
+        log-spaced grid scaled by ``trace(MᵀM)/N``.
+    eps
+        DC-mode floor passed to :class:`SpectralPrior`.
+    """
+
+    alpha_grid: Optional[np.ndarray] = None
+    lambda_grid: Optional[np.ndarray] = None
+    eps: float = 1e-3
+
+    def __call__(
+        self, design_matrix: np.ndarray, data: np.ndarray,
+    ) -> tuple[float, float]:
+        M = np.asarray(design_matrix, dtype=float)
+        y = np.asarray(data, dtype=float).reshape(-1)
+        n = M.shape[0]
+
+        alpha_grid = (
+            np.asarray(self.alpha_grid)
+            if self.alpha_grid is not None
+            else np.array([0.0, 0.5, 1.0, 1.5, 2.0, 3.0])
+        )
+        lambda_grid = (
+            self.lambda_grid
+            if self.lambda_grid is not None
+            else _default_lambda_grid(M)
+        )
+
+        E = M.T @ M
+        eigvals, eigvecs = np.linalg.eigh(E)
+        proj = eigvecs.T @ (M.T @ y)
+        y_norm2 = float(y @ y)
+
+        best_score = np.inf
+        best_alpha = float(alpha_grid[0])
+        best_lmbda = float(lambda_grid[0])
+
+        for alpha in alpha_grid:
+            prior = SpectralPrior(alpha=float(alpha), eps=self.eps)
+            unit_diag = np.asarray(
+                prior(fobj=None, E_tilda_lm=E, lmbda=1.0), dtype=float
+            )
+            unit_shift_mean = float(np.mean(unit_diag))
+            for lam in lambda_grid:
+                shift = unit_shift_mean * float(lam)
+                denom = eigvals + shift
+                if np.any(denom <= 0):
+                    continue
+                ratio = eigvals / denom
+                residual2 = max(
+                    y_norm2 - float(np.sum((proj ** 2) * (2 * ratio - ratio ** 2))),
+                    0.0,
+                )
+                trH = float(np.sum(ratio))
+                denom_gcv = (n - trH) ** 2
+                if denom_gcv <= 0:
+                    continue
+                score = residual2 / denom_gcv
+                if score < best_score:
+                    best_score = score
+                    best_alpha = float(alpha)
+                    best_lmbda = float(lam)
+        return best_alpha, best_lmbda
+
+
+# -----------------------------------------------------------------------------
+# Convenience constructor
+# -----------------------------------------------------------------------------
+
+
+def build_spectral_prior(
+    topography: np.ndarray,
+    design_matrix: np.ndarray,
+    data: np.ndarray,
+    *,
+    alpha_selector: Optional[AlphaSelector] = None,
+    lambda_selector: Optional[LambdaSelector] = None,
+    joint_selector: Optional[JointGCVSelector] = None,
+    eps: float = 1e-3,
+) -> Hyperparams:
+    """One-call construction of a fully-specified ``SpectralPrior``.
+
+    Two modes:
+
+    - **Sequential (default):** alpha selected first (from the
+      ``topography`` field), then lambda selected given alpha (from
+      ``design_matrix``, ``data``). Pass ``alpha_selector`` and/or
+      ``lambda_selector`` to override the defaults
+      (``EmpiricalSpectralSlope`` + ``GCVSelector``).
+    - **Joint:** pass ``joint_selector=JointGCVSelector(...)`` to
+      pick both alpha and lambda from one held-out-error
+      optimization on ``(design_matrix, data)``. Overrides any
+      sequential selectors. Recommended when ``EmpiricalSpectralSlope``
+      gives an alpha you don't trust (e.g., on cells where the
+      periodogram fit has low R² or yields very steep slopes).
+
+    Parameters
+    ----------
+    topography
+        2D topography field used only for alpha selection in the
+        sequential mode. Ignored when ``joint_selector`` is set.
+    design_matrix
+        Dense ``M`` matrix, shape ``(n_points, n_modes)``.
+    data
+        Target vector that the LSQ fit targets. Typically
+        ``cell.topo_m``.
+    alpha_selector, lambda_selector
+        Sequential-mode selector overrides. Pass ``FixedAlpha`` /
+        ``FixedLambda`` to short-circuit either step. Ignored when
+        ``joint_selector`` is set.
+    joint_selector
+        Joint-mode override. Currently :class:`JointGCVSelector` is
+        the only implementation.
+    eps
+        Passed through to :class:`SpectralPrior` (DC-mode floor).
+
+    Returns
+    -------
+    Hyperparams
+        Bundle of ``alpha``, ``lmbda``, ``prior``, and (only in
+        sequential mode with ``EmpiricalSpectralSlope``)
+        ``slope_fit``. Thread both ``lmbda`` and ``prior`` into
+        ``lin_reg.do`` — passing one without the other defeats the
+        selection.
+    """
+    if joint_selector is not None:
+        alpha, lmbda = joint_selector(design_matrix, data)
+        return Hyperparams(
+            alpha=float(alpha),
+            lmbda=float(lmbda),
+            prior=SpectralPrior(alpha=float(alpha), eps=eps),
+            slope_fit=None,
+        )
+
+    alpha_selector = alpha_selector or EmpiricalSpectralSlope()
+    lambda_selector = lambda_selector or GCVSelector()
+
+    alpha_result = alpha_selector(topography)
+    if isinstance(alpha_result, SlopeFit):
+        alpha = alpha_result.alpha
+        slope_fit: Optional[SlopeFit] = alpha_result
+    else:
+        alpha = float(alpha_result)
+        slope_fit = None
+
+    def factory(a: float) -> SpectralPrior:
+        return SpectralPrior(alpha=a, eps=eps)
+
+    lmbda = lambda_selector(
+        design_matrix, data, alpha=alpha, prior_factory=factory
+    )
+    return Hyperparams(
+        alpha=alpha,
+        lmbda=float(lmbda),
+        prior=SpectralPrior(alpha=alpha, eps=eps),
+        slope_fit=slope_fit,
+    )
+
+
+__all__ = [
+    "SlopeFit",
+    "Hyperparams",
+    "AlphaSelector",
+    "LambdaSelector",
+    "FixedAlpha",
+    "EmpiricalSpectralSlope",
+    "FixedLambda",
+    "GCVSelector",
+    "MarginalLikelihoodSelector",
+    "SpatialCVSelector",
+    "JointGCVSelector",
+    "build_spectral_prior",
+]

--- a/pycsa/core/hyperparams.py
+++ b/pycsa/core/hyperparams.py
@@ -47,7 +47,6 @@ import numpy as np
 
 from pycsa.core.priors import SpectralPrior
 
-
 # -----------------------------------------------------------------------------
 # Records and protocols
 # -----------------------------------------------------------------------------
@@ -225,11 +224,12 @@ class EmpiricalSpectralSlope:
             )
         # Linear fit in log-log space.
         from scipy.stats import linregress
+
         result = linregress(bin_log_k[keep], bin_log_P[keep])
         # P ~ k^(-alpha) ⇒ slope = -alpha
         alpha = float(-result.slope)
         stderr = float(result.stderr)
-        r2 = float(result.rvalue ** 2)
+        r2 = float(result.rvalue**2)
         return SlopeFit(alpha=alpha, stderr=stderr, r_squared=r2)
 
 
@@ -301,16 +301,14 @@ class GCVSelector:
         E = M.T @ M
         # MᵀM is symmetric PSD; use eigh.
         eigvals, eigvecs = np.linalg.eigh(E)
-        Mt_y = M.T @ y                       # shape (N,)
-        proj = eigvecs.T @ Mt_y              # shape (N,)
+        Mt_y = M.T @ y  # shape (N,)
+        proj = eigvecs.T @ Mt_y  # shape (N,)
         y_norm2 = float(y @ y)
         prior = prior_factory(alpha)
         # Trial-prior diagonal: build a representative diag at lmbda=1
         # then scale it linearly per candidate (the spec defines
         # Λ_m ∝ lmbda).
-        unit_diag = np.asarray(
-            prior(fobj=None, E_tilda_lm=E, lmbda=1.0), dtype=float
-        )
+        unit_diag = np.asarray(prior(fobj=None, E_tilda_lm=E, lmbda=1.0), dtype=float)
         # GCV does not care about the eigenvector basis for Λ — we
         # approximate Λ as diagonal in the eigenbasis of MᵀM by taking
         # its mean. This is exact for IsotropicPrior and a good
@@ -329,7 +327,7 @@ class GCVSelector:
             # â projected onto eigenbasis: proj * eigvals / denom; then
             # residual² = ||y||² - 2 yᵀM â + âᵀ MᵀM â reduces to:
             ratio = eigvals / denom
-            residual2 = y_norm2 - float(np.sum((proj ** 2) * (2 * ratio - ratio ** 2)))
+            residual2 = y_norm2 - float(np.sum((proj**2) * (2 * ratio - ratio**2)))
             trH = float(np.sum(ratio))
             denom_gcv = (n - trH) ** 2
             if denom_gcv <= 0:
@@ -523,7 +521,9 @@ class JointGCVSelector:
     eps: float = 1e-3
 
     def __call__(
-        self, design_matrix: np.ndarray, data: np.ndarray,
+        self,
+        design_matrix: np.ndarray,
+        data: np.ndarray,
     ) -> tuple[float, float]:
         M = np.asarray(design_matrix, dtype=float)
         y = np.asarray(data, dtype=float).reshape(-1)
@@ -562,7 +562,7 @@ class JointGCVSelector:
                     continue
                 ratio = eigvals / denom
                 residual2 = max(
-                    y_norm2 - float(np.sum((proj ** 2) * (2 * ratio - ratio ** 2))),
+                    y_norm2 - float(np.sum((proj**2) * (2 * ratio - ratio**2))),
                     0.0,
                 )
                 trH = float(np.sum(ratio))
@@ -660,9 +660,7 @@ def build_spectral_prior(
     def factory(a: float) -> SpectralPrior:
         return SpectralPrior(alpha=a, eps=eps)
 
-    lmbda = lambda_selector(
-        design_matrix, data, alpha=alpha, prior_factory=factory
-    )
+    lmbda = lambda_selector(design_matrix, data, alpha=alpha, prior_factory=factory)
     return Hyperparams(
         alpha=alpha,
         lmbda=float(lmbda),

--- a/pycsa/core/io.py
+++ b/pycsa/core/io.py
@@ -1504,7 +1504,7 @@ class nc_writer(object):
         self.n_modes = params.n_modes
         rootgrp.close()
 
-    def output(self, id, clat, clon, is_land, analysis=None):
+    def output(self, id, clat, clon, is_land, analysis=None, topo_mean=None):
 
         rootgrp = nc.Dataset(self.path + self.fn, "a", format="NETCDF4")
 
@@ -1517,6 +1517,14 @@ class nc_writer(object):
         clat_var[:] = clat
         clon_var = grp.createVariable("clon", "f8")
         clon_var[:] = clon
+
+        if topo_mean is not None:
+            mean_elev_var = grp.createVariable("cell_mean_elevation", "f8")
+            mean_elev_var[:] = topo_mean
+            mean_elev_var.units = "m"
+            mean_elev_var.long_name = (
+                "Mean cell elevation subtracted before spectral analysis"
+            )
 
         if analysis is not None:
             dk_var = grp.createVariable("dk", "f8")
@@ -1558,6 +1566,14 @@ class nc_writer(object):
             cell_area_var.units = "m^2"
             cell_area_var.long_name = "Area of ICON grid cell"
 
+        if struct.topo_mean is not None:
+            mean_elev_var = grp.createVariable("cell_mean_elevation", "f8")
+            mean_elev_var[:] = struct.topo_mean
+            mean_elev_var.units = "m"
+            mean_elev_var.long_name = (
+                "Mean cell elevation subtracted before spectral analysis"
+            )
+
         if struct.is_land:
             dk_var = grp.createVariable("dk", "f8")
             dk_var[:] = struct.dk
@@ -1591,6 +1607,14 @@ class nc_writer(object):
             clat_var[:] = struct.clat
             clon_var = grp.createVariable("clon", "f8")
             clon_var[:] = struct.clon
+
+            if getattr(struct, "topo_mean", None) is not None:
+                mean_elev_var = grp.createVariable("cell_mean_elevation", "f8")
+                mean_elev_var[:] = struct.topo_mean
+                mean_elev_var.units = "m"
+                mean_elev_var.long_name = (
+                    "Mean cell elevation subtracted before spectral analysis"
+                )
 
             if struct.is_land:
                 dk_var = grp.createVariable("dk", "f8")
@@ -1637,12 +1661,22 @@ class nc_writer(object):
         return True
 
     class grp_struct(object):
-        def __init__(self, c_idx, clat, clon, is_land, analysis=None, cell_area=None):
+        def __init__(
+            self,
+            c_idx,
+            clat,
+            clon,
+            is_land,
+            analysis=None,
+            cell_area=None,
+            topo_mean=None,
+        ):
             self.c_idx = c_idx
             self.clat = clat
             self.clon = clon
             self.is_land = is_land
             self.cell_area = cell_area
+            self.topo_mean = topo_mean
 
             self.dk = None
             self.dl = None

--- a/pycsa/core/lin_reg.py
+++ b/pycsa/core/lin_reg.py
@@ -79,6 +79,7 @@ def do(
     ctx=None,
     buffer_pool=None,
     use_sparse=False,
+    prior=None,
 ):
     """
     Does the linear regression with optional buffer pool and sparse solver
@@ -97,11 +98,19 @@ def do(
         skips the linear regression and just saves the generated ``M`` matrix for diagnostics and debugging, by default False
     ctx : ComputeContext, optional
         Compute context bundling the buffer pool. If absent, defaults to
-        ``fobj.ctx``.
+        ``fobj.ctx``. If ``ctx.prior`` is set and the ``prior`` kwarg is
+        ``None``, the context's prior is used.
     buffer_pool : BufferPool, optional
         **Deprecated.** Pass ``ctx=ComputeContext(buffer_pool=...)`` instead.
     use_sparse : bool, optional
         Use sparse matrix solver (automatic for few modes), by default False
+    prior : :class:`pycsa.core.priors.Prior`, optional
+        Pluggable Tikhonov diagonal generator. When ``None`` (default),
+        the existing scalar-trace branch is used and numerics are
+        bit-identical to historical behavior. When supplied, the prior is
+        called as ``prior(fobj, E_tilda_lm, lmbda=lmbda)`` and the returned
+        diagonal is added to ``diag(E_tilda_lm)``. Opt-in only; no
+        production caller passes this kwarg.
 
     Returns
     -------
@@ -116,6 +125,11 @@ def do(
         ctx = getattr(fobj, "ctx", None)
     ctx = _resolve_ctx(ctx, buffer_pool)
     buffer_pool = ctx.buffer_pool
+
+    # ctx-level prior fallback: explicit kwarg wins, otherwise pick up
+    # whatever the context carries (None for default ComputeContexts).
+    if prior is None:
+        prior = getattr(ctx, "prior", None)
 
     if fobj.grad:
         cell.get_grad()
@@ -151,10 +165,29 @@ def do(
 
         # Add regularization to sparse matrix
         if lmbda > 0:
-            trace = E_tilda_lm_sparse.diagonal().mean() * lmbda
-            E_tilda_lm_sparse = E_tilda_lm_sparse + trace * eye(
-                E_tilda_lm_sparse.shape[0]
-            )
+            if prior is None:
+                trace = E_tilda_lm_sparse.diagonal().mean() * lmbda
+                E_tilda_lm_sparse = E_tilda_lm_sparse + trace * eye(
+                    E_tilda_lm_sparse.shape[0]
+                )
+            else:
+                # Densify just for the prior call (it expects the dense
+                # normal-equations matrix); the actual solve stays sparse.
+                E_dense_view = E_tilda_lm_sparse.toarray()
+                diag_add = np.asarray(
+                    prior(fobj, E_dense_view, lmbda=lmbda), dtype=float
+                )
+                if diag_add.shape != (E_tilda_lm_sparse.shape[0],):
+                    raise ValueError(
+                        "prior returned diag of shape %s; expected %s"
+                        % (diag_add.shape, (E_tilda_lm_sparse.shape[0],))
+                    )
+                # Inject the prior diagonal into the sparse matrix in-place
+                # by adding a sparse diag matrix.
+                from scipy.sparse import diags as _sp_diags
+                E_tilda_lm_sparse = E_tilda_lm_sparse + _sp_diags(
+                    diag_add, 0, shape=E_tilda_lm_sparse.shape
+                )
 
         # Solve with sparse solver (direct solver for sparse SPD matrices)
         # Convert RHS to dense array if it's sparse, otherwise use as-is
@@ -191,8 +224,21 @@ def do(
 
         # Add regularization to diagonal (vectorized for speed)
         if lmbda > 0:
-            trace = np.trace(E_tilda_lm) / E_tilda_lm.shape[0] * lmbda
-            np.fill_diagonal(E_tilda_lm, np.diag(E_tilda_lm) + trace)
+            if prior is None:
+                # Preserved scalar-trace branch — what the reproducibility
+                # fixtures pin down. Bit-identical to historical behavior.
+                trace = np.trace(E_tilda_lm) / E_tilda_lm.shape[0] * lmbda
+                np.fill_diagonal(E_tilda_lm, np.diag(E_tilda_lm) + trace)
+            else:
+                diag_add = np.asarray(
+                    prior(fobj, E_tilda_lm, lmbda=lmbda), dtype=E_tilda_lm.dtype
+                )
+                if diag_add.shape != (E_tilda_lm.shape[0],):
+                    raise ValueError(
+                        "prior returned diag of shape %s; expected %s"
+                        % (diag_add.shape, (E_tilda_lm.shape[0],))
+                    )
+                np.fill_diagonal(E_tilda_lm, np.diag(E_tilda_lm) + diag_add)
 
         # E_tilda_lm is symmetric positive definite (M^T M form with regularization)
         # Use Cholesky decomposition for 2-5x speedup vs GMRES

--- a/pycsa/core/lin_reg.py
+++ b/pycsa/core/lin_reg.py
@@ -185,6 +185,7 @@ def do(
                 # Inject the prior diagonal into the sparse matrix in-place
                 # by adding a sparse diag matrix.
                 from scipy.sparse import diags as _sp_diags
+
                 E_tilda_lm_sparse = E_tilda_lm_sparse + _sp_diags(
                     diag_add, 0, shape=E_tilda_lm_sparse.shape
                 )

--- a/pycsa/core/mode_selection.py
+++ b/pycsa/core/mode_selection.py
@@ -234,9 +234,7 @@ class LassoSelector:
         column_to_kl=None,
     ) -> IndexPair:
         if design_matrix is None or data is None:
-            raise ValueError(
-                "LassoSelector requires design_matrix and data kwargs"
-            )
+            raise ValueError("LassoSelector requires design_matrix and data kwargs")
         try:
             from sklearn.linear_model import Lasso
         except ImportError as exc:
@@ -267,9 +265,7 @@ class LassoSelector:
         return _columns_to_kl(active, fa_spectrum.shape, column_to_kl)
 
 
-def _columns_to_kl(
-    columns, spectrum_shape, column_to_kl
-) -> IndexPair:
+def _columns_to_kl(columns, spectrum_shape, column_to_kl) -> IndexPair:
     """Convert a list of design-matrix column indices into ``(k_idxs, l_idxs)``.
 
     If ``column_to_kl`` is provided, applies it. Otherwise assumes

--- a/pycsa/core/mode_selection.py
+++ b/pycsa/core/mode_selection.py
@@ -1,0 +1,300 @@
+"""Pluggable mode selectors for the FA -> SA bridge.
+
+The default selection step in :class:`pycsa.wrappers.interface.second_appx`
+is a greedy ``argmax`` loop on the FA spectrum (lines 556-571): pick the
+largest amplitude, zero it, repeat ``n_modes`` times. That loop is
+preserved unchanged — it is what every existing call site hits and
+what the reproducibility fixtures pin down.
+
+This module introduces a ``ModeSelector`` protocol so spike scripts
+can experiment with sparsity-inducing alternatives (OMP, Lasso)
+without touching the default code path. A selector takes the FA
+spectrum (and optionally the design matrix + data) and returns the
+``(k_idxs, l_idxs)`` pair that ``fobj.set_kls`` expects.
+
+``GreedyArgmax`` is a 1-to-1 reimplementation of the inline loop.
+Unit-tested for bit-equivalent output on a synthetic FA spectrum.
+
+``OMPSelector`` and ``LassoSelector`` are the alternatives under
+test in the spike. They require access to the design matrix and
+the residual signal — these are passed through optional kwargs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Protocol, Tuple
+
+import numpy as np
+
+# k_idxs and l_idxs are passed to ``fobj.set_kls`` which currently
+# accepts list-like inputs; we keep the return type as lists to
+# match the existing call convention at interface.py:570-571.
+IndexPair = Tuple[list, list]
+
+
+class ModeSelector(Protocol):
+    """Callable that selects ``n_modes`` Fourier modes from the FA spectrum.
+
+    Parameters
+    ----------
+    fa_spectrum
+        2D real array of FA amplitudes, shape ``(nhar_j, nhar_i)`` —
+        the same array currently passed to the inline ``argmax``
+        loop at interface.py:556-571. Indexing matches the existing
+        convention: ``axis 0 == l``, ``axis 1 == k``.
+    n_modes
+        Number of modes to select.
+    design_matrix
+        Optional dense design matrix ``M`` of shape
+        ``(n_points, n_columns)`` for selectors that need it (OMP,
+        Lasso). ``GreedyArgmax`` ignores this.
+    data
+        Optional 1D data vector, shape ``(n_points,)``, that the
+        FA fit targeted. Selectors that fit a sparse representation
+        of ``data`` against the columns of ``design_matrix`` use it.
+    column_to_kl
+        Optional callable mapping column index in ``design_matrix``
+        to a ``(k, l)`` index pair compatible with ``fa_spectrum``
+        indexing. Used by OMP/Lasso to convert their selected
+        columns back to the ``(k_idxs, l_idxs)`` format. If absent,
+        the selector assumes columns are laid out in
+        ``np.ndindex(fa_spectrum.shape)`` order.
+
+    Returns
+    -------
+    (k_idxs, l_idxs)
+        Two lists of length ``n_modes`` ready to feed
+        ``fobj.set_kls(k_idxs, l_idxs, ...)``.
+    """
+
+    def __call__(
+        self,
+        fa_spectrum: np.ndarray,
+        *,
+        n_modes: int,
+        design_matrix: Optional[np.ndarray] = None,
+        data: Optional[np.ndarray] = None,
+        column_to_kl=None,
+    ) -> IndexPair: ...
+
+
+@dataclass
+class GreedyArgmax:
+    """Reproduces the existing inline argmax loop verbatim.
+
+    Iterates ``n_modes`` times: take ``argmax`` of the current
+    spectrum, record the unravel-index pair, zero that entry,
+    repeat. The recorded pairs are then split as
+    ``k_idxs = [pair[1] for pair in indices]`` and
+    ``l_idxs = [pair[0] for pair in indices]`` to match the
+    convention at interface.py:570-571.
+
+    This is the default selector. Passing ``selector=GreedyArgmax()``
+    to a wrapped ``second_appx`` should produce bit-identical output
+    versus the inline loop.
+    """
+
+    def __call__(
+        self,
+        fa_spectrum: np.ndarray,
+        *,
+        n_modes: int,
+        design_matrix: Optional[np.ndarray] = None,
+        data: Optional[np.ndarray] = None,
+        column_to_kl=None,
+    ) -> IndexPair:
+        # Match the inline loop exactly: operate on a copy, zero entries
+        # as they are picked, do not pre-mask anything.
+        fq = np.copy(fa_spectrum)
+        # NaN-handling is done by the caller (interface.second_appx.do
+        # already zeros NaNs before passing the spectrum in). We do not
+        # re-do it here so behavior remains identical.
+        indices = []
+        for _ in range(n_modes):
+            max_idx = np.unravel_index(fq.argmax(), fq.shape)
+            indices.append(max_idx)
+            fq[max_idx] = 0.0
+        k_idxs = [pair[1] for pair in indices]
+        l_idxs = [pair[0] for pair in indices]
+        return k_idxs, l_idxs
+
+
+@dataclass
+class OMPSelector:
+    """Orthogonal matching pursuit on the design matrix.
+
+    At each step, picks the column of ``design_matrix`` most
+    correlated (in absolute value) with the current residual,
+    re-fits the active set by ordinary least squares, and updates
+    the residual. Repeats until ``n_modes`` columns are selected.
+
+    Requires ``design_matrix`` and ``data``. Raises ``ValueError``
+    if either is missing.
+
+    Parameters
+    ----------
+    batch_size
+        Number of correlations selected per step. ``batch_size=1``
+        is canonical OMP. Larger values (e.g. 5) trade some
+        optimality for cost — only one ``do_full`` + active-set
+        solve per batch.
+    column_offset
+        Index into ``design_matrix`` columns to skip (e.g. the DC
+        mode if the caller prefers OMP to ignore it). Defaults to
+        0, meaning all columns are candidates.
+    """
+
+    batch_size: int = 1
+    column_offset: int = 0
+
+    def __call__(
+        self,
+        fa_spectrum: np.ndarray,
+        *,
+        n_modes: int,
+        design_matrix: Optional[np.ndarray] = None,
+        data: Optional[np.ndarray] = None,
+        column_to_kl=None,
+    ) -> IndexPair:
+        if design_matrix is None or data is None:
+            raise ValueError(
+                "OMPSelector requires design_matrix and data kwargs; "
+                "got design_matrix=%r, data=%r" % (design_matrix, data)
+            )
+        M = np.asarray(design_matrix, dtype=float)
+        y = np.asarray(data, dtype=float).reshape(-1)
+        if M.shape[0] != y.shape[0]:
+            raise ValueError(
+                f"design_matrix rows ({M.shape[0]}) and data length "
+                f"({y.shape[0]}) disagree"
+            )
+
+        n_cols = M.shape[1]
+        candidates = list(range(self.column_offset, n_cols))
+        active: list[int] = []
+        residual = y.copy()
+
+        col_norms = np.linalg.norm(M[:, candidates], axis=0)
+        col_norms[col_norms == 0.0] = 1.0  # avoid div-by-zero
+
+        while len(active) < n_modes and candidates:
+            # Correlation of each candidate column with the current residual,
+            # normalized by column norm (cosine-like score).
+            sub = M[:, candidates]
+            scores = np.abs(sub.T @ residual) / col_norms
+            step = min(self.batch_size, n_modes - len(active), len(candidates))
+            top = np.argpartition(-scores, step - 1)[:step]
+            picked = [candidates[i] for i in top]
+            active.extend(picked)
+            # Remove picked columns and their norms from the candidate pool.
+            keep = [i for i in range(len(candidates)) if i not in set(top)]
+            candidates = [candidates[i] for i in keep]
+            col_norms = col_norms[keep]
+            # Re-fit active set via lstsq, update residual.
+            M_active = M[:, active]
+            coef, *_ = np.linalg.lstsq(M_active, y, rcond=None)
+            residual = y - M_active @ coef
+
+        return _columns_to_kl(active, fa_spectrum.shape, column_to_kl)
+
+
+@dataclass
+class LassoSelector:
+    """L1-penalised regression via coordinate descent.
+
+    Wraps ``sklearn.linear_model.Lasso``. Selects the ``n_modes``
+    largest-magnitude non-zero coefficients (pads with zeros if
+    Lasso returns fewer non-zeros than ``n_modes``).
+
+    Parameters
+    ----------
+    alpha
+        Lasso penalty strength. ``None`` triggers a small k-fold CV
+        over a log-spaced grid (left to the spike-script layer in
+        phase 1; in the protocol layer here, ``alpha=None`` falls
+        back to a sensible default of ``1e-3 * ‖Mᵀ y‖∞``).
+    column_offset
+        See :class:`OMPSelector`.
+    max_iter
+        Lasso solver max iterations.
+    """
+
+    alpha: Optional[float] = None
+    column_offset: int = 0
+    max_iter: int = 10_000
+
+    def __call__(
+        self,
+        fa_spectrum: np.ndarray,
+        *,
+        n_modes: int,
+        design_matrix: Optional[np.ndarray] = None,
+        data: Optional[np.ndarray] = None,
+        column_to_kl=None,
+    ) -> IndexPair:
+        if design_matrix is None or data is None:
+            raise ValueError(
+                "LassoSelector requires design_matrix and data kwargs"
+            )
+        try:
+            from sklearn.linear_model import Lasso
+        except ImportError as exc:
+            raise ImportError(
+                "LassoSelector requires scikit-learn. Install it or use a "
+                "different selector."
+            ) from exc
+
+        M = np.asarray(design_matrix, dtype=float)
+        y = np.asarray(data, dtype=float).reshape(-1)
+        sub = M[:, self.column_offset :]
+
+        if self.alpha is None:
+            scale = float(np.max(np.abs(sub.T @ y))) / max(sub.shape[0], 1)
+            alpha = 1e-3 * max(scale, 1e-12)
+        else:
+            alpha = float(self.alpha)
+
+        model = Lasso(alpha=alpha, max_iter=self.max_iter, fit_intercept=False)
+        model.fit(sub, y)
+        coef = np.abs(model.coef_)
+        # Take up to n_modes largest-magnitude indices among non-zeros;
+        # if fewer non-zeros than n_modes, fill the remainder with the
+        # next largest |coefficients| (still informative for the spike).
+        order = np.argsort(-coef)
+        picked = order[:n_modes]
+        active = (picked + self.column_offset).tolist()
+        return _columns_to_kl(active, fa_spectrum.shape, column_to_kl)
+
+
+def _columns_to_kl(
+    columns, spectrum_shape, column_to_kl
+) -> IndexPair:
+    """Convert a list of design-matrix column indices into ``(k_idxs, l_idxs)``.
+
+    If ``column_to_kl`` is provided, applies it. Otherwise assumes
+    columns are laid out in ``np.ndindex(spectrum_shape)`` order —
+    i.e. row-major over ``(l, k)`` to match the FA spectrum's
+    ``(nhar_j, nhar_i)`` layout.
+    """
+    if column_to_kl is not None:
+        pairs = [column_to_kl(c) for c in columns]
+    else:
+        nhar_j, nhar_i = spectrum_shape
+        pairs = []
+        for c in columns:
+            # Same order as np.ndindex((nhar_j, nhar_i))
+            l = c // nhar_i
+            k = c % nhar_i
+            pairs.append((k, l))
+    k_idxs = [p[0] for p in pairs]
+    l_idxs = [p[1] for p in pairs]
+    return k_idxs, l_idxs
+
+
+__all__ = [
+    "ModeSelector",
+    "GreedyArgmax",
+    "OMPSelector",
+    "LassoSelector",
+]

--- a/pycsa/core/priors.py
+++ b/pycsa/core/priors.py
@@ -1,0 +1,190 @@
+"""Pluggable Tikhonov priors for the linear-fit step.
+
+The default fit in :func:`pycsa.core.lin_reg.do` adds a scalar
+``lmbda * trace(MᵀM)/N`` to the diagonal of the normal-equations
+matrix. That branch is preserved unchanged — it is what every
+existing call site hits and what the reproducibility fixtures
+pin down.
+
+This module introduces a ``Prior`` protocol so spike scripts can
+experiment with structured (per-mode) regularization without
+touching the default code path. A prior is a callable that returns
+the diagonal vector to add to ``diag(E_tilda_lm)``.
+
+``IsotropicPrior`` is a parallel implementation of the existing
+scalar-trace branch. It is NOT routed through by default; passing
+``prior=IsotropicPrior()`` to ``lin_reg.do`` should produce the
+same numerical result as ``prior=None``, within floating-point
+re-association noise (the parallel path computes the same scalar
+but the assignment sequence is different). Unit-tested for parity
+on a synthetic ``E_tilda_lm``.
+
+``SpectralPrior`` is the alternative under test in the spike: a
+per-mode prior whose diagonal grows with wavenumber norm.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Protocol
+
+import numpy as np
+
+
+class Prior(Protocol):
+    """Callable that returns the Tikhonov diagonal to add to ``diag(MᵀM)``.
+
+    Parameters
+    ----------
+    fobj
+        The :class:`pycsa.core.fourier.f_trans` instance used to build
+        the design matrix. Carries the mode-index attributes
+        (``m_i``, ``m_j``, optional ``k_idx``/``l_idx``) that structured
+        priors need to compute per-mode weights.
+    E_tilda_lm
+        The dense normal-equations matrix (``MᵀM``), shape ``(N, N)``.
+        Priors may use ``trace(E)`` for scale normalization.
+    lmbda
+        The overall regularization scale (the same scalar that the
+        existing ``lin_reg.do`` accepts).
+
+    Returns
+    -------
+    diag : np.ndarray, shape (N,)
+        Non-negative diagonal to be added to ``diag(E_tilda_lm)``.
+    """
+
+    def __call__(
+        self, fobj, E_tilda_lm: np.ndarray, *, lmbda: float
+    ) -> np.ndarray: ...
+
+
+@dataclass
+class IsotropicPrior:
+    """Parallel implementation of the current scalar-trace diagonal.
+
+    Returns ``lmbda * trace(E) / N * ones(N)``. Equivalent to the
+    inline branch at ``lin_reg.do`` L193-195 (within reassociation
+    noise — the inline branch computes one scalar and broadcasts;
+    this returns an array). Provided so spike scripts can compose
+    it as an explicit baseline alongside other priors.
+
+    Not the default path. ``lin_reg.do(prior=None)`` continues to
+    use the inline branch and produces bit-identical fixture output.
+    """
+
+    def __call__(
+        self, fobj, E_tilda_lm: np.ndarray, *, lmbda: float
+    ) -> np.ndarray:
+        n = E_tilda_lm.shape[0]
+        trace_scale = float(np.trace(E_tilda_lm)) / n * lmbda
+        return np.full(n, trace_scale, dtype=E_tilda_lm.dtype)
+
+
+@dataclass
+class SpectralPrior:
+    """Per-mode prior with diagonal growing with wavenumber norm.
+
+    For each mode ``m`` with wavenumber pair ``(k_m, l_m)``:
+
+    .. math::
+
+        \\lambda_m = \\lambda \\cdot \\frac{\\mathrm{tr}(E)}{N}
+                    \\cdot \\left(
+                        \\frac{\\Vert k_m \\Vert}{\\Vert k \\Vert_{\\max}}
+                        + \\varepsilon
+                    \\right)^\\alpha
+
+    Equivalent to a zero-mean Gaussian prior on the coefficients
+    with variance proportional to ``‖k_m‖^(-alpha)``. Implies an
+    assumed topographic power spectrum behaving like ``‖k‖^(-alpha)``,
+    so ``alpha`` should be calibrated from the input fixture's
+    empirical power-law slope rather than picked from generic
+    physics constants. ``alpha=0`` recovers the isotropic baseline
+    (modulo the ``+ eps`` floor).
+
+    Parameters
+    ----------
+    alpha
+        Spectral decay exponent. ``alpha=0`` reduces to isotropic
+        (constant diagonal at ``(1 + eps)^0 == 1``).
+    eps
+        Small additive floor that keeps the DC mode (``‖k‖ = 0``)
+        from receiving zero regularization. Documented knob, not
+        a free hyperparameter.
+    """
+
+    alpha: float
+    eps: float = 1e-3
+
+    def __call__(
+        self, fobj, E_tilda_lm: np.ndarray, *, lmbda: float
+    ) -> np.ndarray:
+        n = E_tilda_lm.shape[0]
+        weights = _wavenumber_weights(fobj, n)
+        norm = np.max(weights) if weights.size > 0 else 1.0
+        if norm == 0.0:
+            norm = 1.0
+        scaled = (weights / norm + self.eps) ** self.alpha
+        trace_scale = float(np.trace(E_tilda_lm)) / n * lmbda
+        return (trace_scale * scaled).astype(E_tilda_lm.dtype, copy=False)
+
+
+def _wavenumber_weights(fobj, n_modes: int) -> np.ndarray:
+    """Per-column wavenumber norm ``‖k_m‖`` for the design matrix's columns.
+
+    The design matrix produced by ``f_trans.do_full`` has columns
+    laid out as ``[cos_columns | sin_columns]`` after the slicing
+    at fourier.py L215-231. For the spike, we accept a small
+    simplification: we compute the wavenumber norm per ``(m_i, m_j)``
+    pair from ``fobj.m_i`` and ``fobj.m_j``, then duplicate across
+    cos/sin columns. If the column count doesn't divide cleanly,
+    we fall back to a uniform weight (effectively recovering
+    isotropic behavior for that fixture — a safe degradation).
+
+    When ``fobj.pick_kls`` is True, the mode indices come from
+    ``fobj.k_idx``/``fobj.l_idx`` directly.
+    """
+    m_i = getattr(fobj, "m_i", None)
+    m_j = getattr(fobj, "m_j", None)
+    if m_i is None or m_j is None:
+        # fobj not yet configured — fall back to uniform
+        return np.ones(n_modes)
+
+    if getattr(fobj, "pick_kls", False) and hasattr(fobj, "k_idx"):
+        # Sparse mode set: each selected (k_idx[i], l_idx[i]) is one mode.
+        # The design matrix lays cos columns first then sin columns, so the
+        # weights repeat across that split.
+        k_idx = np.asarray(fobj.k_idx)
+        l_idx = np.asarray(fobj.l_idx)
+        mi_sel = np.asarray(m_i)[k_idx % len(m_i)]
+        mj_sel = np.asarray(m_j)[l_idx % len(m_j)]
+        per_mode = np.hypot(mi_sel.astype(float), mj_sel.astype(float))
+        # Duplicate across cos/sin halves if dimensions match
+        if n_modes == 2 * per_mode.size:
+            return np.concatenate([per_mode, per_mode])
+        if n_modes == per_mode.size:
+            return per_mode
+        return np.ones(n_modes)
+
+    # Dense (full) basis case: mode count is roughly nhar_i * nhar_j
+    # split between cos and sin halves. We compute the full
+    # (nhar_i, nhar_j) grid of ‖(m_i, m_j)‖ and flatten in the same
+    # order as the design matrix's columns. The slicing in
+    # f_trans.do_full removes a fixed slab of cos and sin columns;
+    # we approximate by tiling and trimming to ``n_modes``.
+    mi_arr = np.asarray(m_i, dtype=float)
+    mj_arr = np.asarray(m_j, dtype=float)
+    grid = np.hypot(mi_arr[:, None], mj_arr[None, :]).ravel()
+    if grid.size == 0:
+        return np.ones(n_modes)
+    # cos and sin halves both draw from the same wavenumber grid
+    half = (n_modes + 1) // 2
+    tiled = np.concatenate(
+        [np.tile(grid, (half + grid.size) // grid.size + 1)[:half],
+         np.tile(grid, (half + grid.size) // grid.size + 1)[: n_modes - half]]
+    )
+    return tiled[:n_modes]
+
+
+__all__ = ["Prior", "IsotropicPrior", "SpectralPrior"]

--- a/pycsa/core/priors.py
+++ b/pycsa/core/priors.py
@@ -54,9 +54,7 @@ class Prior(Protocol):
         Non-negative diagonal to be added to ``diag(E_tilda_lm)``.
     """
 
-    def __call__(
-        self, fobj, E_tilda_lm: np.ndarray, *, lmbda: float
-    ) -> np.ndarray: ...
+    def __call__(self, fobj, E_tilda_lm: np.ndarray, *, lmbda: float) -> np.ndarray: ...
 
 
 @dataclass
@@ -73,9 +71,7 @@ class IsotropicPrior:
     use the inline branch and produces bit-identical fixture output.
     """
 
-    def __call__(
-        self, fobj, E_tilda_lm: np.ndarray, *, lmbda: float
-    ) -> np.ndarray:
+    def __call__(self, fobj, E_tilda_lm: np.ndarray, *, lmbda: float) -> np.ndarray:
         n = E_tilda_lm.shape[0]
         trace_scale = float(np.trace(E_tilda_lm)) / n * lmbda
         return np.full(n, trace_scale, dtype=E_tilda_lm.dtype)
@@ -117,9 +113,7 @@ class SpectralPrior:
     alpha: float
     eps: float = 1e-3
 
-    def __call__(
-        self, fobj, E_tilda_lm: np.ndarray, *, lmbda: float
-    ) -> np.ndarray:
+    def __call__(self, fobj, E_tilda_lm: np.ndarray, *, lmbda: float) -> np.ndarray:
         n = E_tilda_lm.shape[0]
         weights = _wavenumber_weights(fobj, n)
         norm = np.max(weights) if weights.size > 0 else 1.0
@@ -181,8 +175,10 @@ def _wavenumber_weights(fobj, n_modes: int) -> np.ndarray:
     # cos and sin halves both draw from the same wavenumber grid
     half = (n_modes + 1) // 2
     tiled = np.concatenate(
-        [np.tile(grid, (half + grid.size) // grid.size + 1)[:half],
-         np.tile(grid, (half + grid.size) // grid.size + 1)[: n_modes - half]]
+        [
+            np.tile(grid, (half + grid.size) // grid.size + 1)[:half],
+            np.tile(grid, (half + grid.size) // grid.size + 1)[: n_modes - half],
+        ]
     )
     return tiled[:n_modes]
 

--- a/pycsa/core/validation.py
+++ b/pycsa/core/validation.py
@@ -72,9 +72,7 @@ def _build_spatial_folds(
     xmin, xmax = float(np.min(x)), float(np.max(x))
     ymin, ymax = float(np.min(y)), float(np.max(y))
     if xmax == xmin or ymax == ymin:
-        raise ValueError(
-            "coords have zero extent in at least one axis — cannot tile"
-        )
+        raise ValueError("coords have zero extent in at least one axis — cannot tile")
     # Near-square grid of tiles. Pick r and c so r*c >= n_folds and the
     # aspect ratio of the tile matches the aspect ratio of the bounding box.
     aspect = (xmax - xmin) / (ymax - ymin)
@@ -186,7 +184,9 @@ def spatial_cv_score(
                 f"design_matrix rows ({n})"
             )
     folds = _build_spatial_folds(
-        coords_array, n_folds=n_folds, buffer_fraction=buffer_fraction,
+        coords_array,
+        n_folds=n_folds,
+        buffer_fraction=buffer_fraction,
         rng_seed=rng_seed,
     )
 
@@ -196,9 +196,7 @@ def spatial_cv_score(
         M_tr, y_tr = M[train_idx], y[train_idx]
         M_ev, y_ev = M[eval_idx], y[eval_idx]
         E = M_tr.T @ M_tr
-        diag_add = np.asarray(
-            prior(fobj=None, E_tilda_lm=E, lmbda=lmbda), dtype=float
-        )
+        diag_add = np.asarray(prior(fobj=None, E_tilda_lm=E, lmbda=lmbda), dtype=float)
         if diag_add.shape != (E.shape[0],):
             raise ValueError(
                 f"prior returned diag of shape {diag_add.shape}; "

--- a/pycsa/core/validation.py
+++ b/pycsa/core/validation.py
@@ -1,0 +1,225 @@
+"""Held-out validation utilities for the structured prior.
+
+Two callables here. :func:`spatial_cv_score` is the workhorse —
+it runs k-fold spatial cross-validation for an arbitrary
+:class:`pycsa.core.priors.Prior` at a fixed ``lmbda``, returning
+the per-fold and mean held-out MSE. :class:`SpatialCVSelector` in
+``hyperparams.py`` uses it internally over a ``lmbda`` grid; users
+can call it directly to validate *any* prior choice without going
+through a selector.
+
+**Patch geometry, made concrete.** Phase 1's plan flagged this as
+the most under-specified piece. The implementation here:
+
+- Takes per-row coordinates as a ``(n_points, 2)`` array (any
+  metric — local Cartesian, (lon, lat), whatever the caller's
+  cell uses). When ``coords`` is ``None`` we fall back to
+  ``cell.lon_m``-style row-index ordering — that is, we treat
+  the points as already in scan-line order and split by index.
+  That's the only setting where the fallback is correct; the
+  caller is responsible for providing real coordinates when the
+  data is on a Delaunay grid or any other non-scan-line layout.
+- Computes a 2D bounding box from the supplied coords, partitions
+  it into a near-square ``r × c`` grid where ``r·c ≥ n_folds``,
+  and assigns each fold to one tile. Excess tiles are unused.
+  Tiles are contiguous in coordinate space — this is what
+  ``spatial`` cross-validation actually means; per-point random
+  shuffling leaks long-wavelength modes across folds and would
+  silently overstate held-out accuracy.
+- Each held-out tile has a buffer zone of width
+  ``buffer_fraction · tile_side`` around it. Points inside the
+  buffer are excluded from both the training set and the
+  evaluation set for that fold.
+
+Documented limitation: works for cells whose points roughly fill a
+2D region (MERIT regional cells, ETOPO regional cells). For ICON
+Delaunay-triangle cells with sparse coverage near a cell vertex
+the bounding-box partition may produce empty tiles — the function
+raises in that case so the failure is visible.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+import scipy.linalg as la
+
+from pycsa.core.priors import Prior
+
+
+def _build_spatial_folds(
+    coords: np.ndarray,
+    n_folds: int,
+    buffer_fraction: float,
+    rng_seed: Optional[int],
+) -> list:
+    """Return list of length n_folds; each entry is (train_idx, eval_idx).
+
+    Folds are contiguous in coordinate space. Buffer points are
+    excluded from both training and evaluation for the corresponding
+    fold. The caller is responsible for verifying that each fold has
+    non-empty train + eval sets — we raise otherwise.
+    """
+    rng = np.random.default_rng(rng_seed)
+    n = coords.shape[0]
+    if n < 2 * n_folds:
+        raise ValueError(
+            f"Need at least 2*n_folds={2 * n_folds} points to split; got {n}"
+        )
+    x = coords[:, 0]
+    y = coords[:, 1]
+    xmin, xmax = float(np.min(x)), float(np.max(x))
+    ymin, ymax = float(np.min(y)), float(np.max(y))
+    if xmax == xmin or ymax == ymin:
+        raise ValueError(
+            "coords have zero extent in at least one axis — cannot tile"
+        )
+    # Near-square grid of tiles. Pick r and c so r*c >= n_folds and the
+    # aspect ratio of the tile matches the aspect ratio of the bounding box.
+    aspect = (xmax - xmin) / (ymax - ymin)
+    side = int(np.ceil(np.sqrt(n_folds)))
+    r = max(int(np.ceil(side / np.sqrt(aspect))), 1)
+    c = max(int(np.ceil(n_folds / r)), 1)
+    # tile_x, tile_y are the per-tile widths in coord units
+    tile_x = (xmax - xmin) / c
+    tile_y = (ymax - ymin) / r
+    buffer_x = buffer_fraction * tile_x
+    buffer_y = buffer_fraction * tile_y
+
+    # Pick n_folds tile centers in a deterministic interleaved order so
+    # the chosen folds are spatially spread rather than packed in one
+    # corner.
+    tile_ids = list(range(r * c))
+    rng.shuffle(tile_ids)
+    chosen = tile_ids[:n_folds]
+
+    folds = []
+    for tile_id in chosen:
+        ti, tj = divmod(tile_id, c)
+        xlo = xmin + tj * tile_x
+        xhi = xlo + tile_x
+        ylo = ymin + ti * tile_y
+        yhi = ylo + tile_y
+        eval_mask = (x >= xlo) & (x < xhi) & (y >= ylo) & (y < yhi)
+        buffer_mask = (
+            (x >= xlo - buffer_x)
+            & (x < xhi + buffer_x)
+            & (y >= ylo - buffer_y)
+            & (y < yhi + buffer_y)
+        )
+        train_mask = ~buffer_mask  # buffer excludes both train and eval
+        eval_idx = np.where(eval_mask)[0]
+        train_idx = np.where(train_mask)[0]
+        if eval_idx.size == 0:
+            raise ValueError(
+                f"Fold tile ({ti}, {tj}) has no eval points — "
+                "data is too sparse for the requested n_folds; "
+                "lower n_folds or supply denser coords"
+            )
+        if train_idx.size < 2:
+            raise ValueError(
+                f"Fold tile ({ti}, {tj}) leaves < 2 training points — "
+                "lower buffer_fraction or n_folds"
+            )
+        folds.append((train_idx, eval_idx))
+    return folds
+
+
+def spatial_cv_score(
+    prior: Prior,
+    lmbda: float,
+    design_matrix: np.ndarray,
+    data: np.ndarray,
+    *,
+    coords: Optional[np.ndarray] = None,
+    n_folds: int = 5,
+    buffer_fraction: float = 0.1,
+    rng_seed: Optional[int] = None,
+) -> dict:
+    """K-fold spatial cross-validation for any :class:`Prior`.
+
+    Solves the regularized normal equations on each fold's training
+    rows, predicts the held-out rows, and returns the per-fold and
+    mean reconstruction MSE.
+
+    Parameters
+    ----------
+    prior
+        Any :class:`pycsa.core.priors.Prior`. Called per-fold with
+        the fold's normal-equations matrix.
+    lmbda
+        Regularization scale passed to the prior.
+    design_matrix
+        Dense ``M`` matrix, shape ``(n_points, n_modes)``.
+    data
+        Target vector, shape ``(n_points,)``.
+    coords
+        Per-row 2D coordinates for spatial fold construction. If
+        ``None``, falls back to a strided index split — only
+        appropriate when rows are already in scan-line order.
+    n_folds, buffer_fraction, rng_seed
+        See module docstring.
+
+    Returns
+    -------
+    dict with keys:
+        ``per_fold_mse``
+            ndarray of length ``n_folds``.
+        ``mean_heldout_mse``
+            Mean of ``per_fold_mse``.
+        ``fold_sizes``
+            ndarray of shape ``(n_folds, 2)`` — (n_train, n_eval) per fold.
+    """
+    M = np.asarray(design_matrix, dtype=float)
+    y = np.asarray(data, dtype=float).reshape(-1)
+    n = M.shape[0]
+    if coords is None:
+        # Strided index split — only correct if rows are scan-line
+        # ordered. Document the assumption in the result.
+        coords_array = np.column_stack([np.arange(n), np.zeros(n)])
+    else:
+        coords_array = np.asarray(coords, dtype=float)
+        if coords_array.shape[0] != n:
+            raise ValueError(
+                f"coords rows ({coords_array.shape[0]}) must match "
+                f"design_matrix rows ({n})"
+            )
+    folds = _build_spatial_folds(
+        coords_array, n_folds=n_folds, buffer_fraction=buffer_fraction,
+        rng_seed=rng_seed,
+    )
+
+    per_fold_mse = np.full(n_folds, np.nan)
+    fold_sizes = np.zeros((n_folds, 2), dtype=int)
+    for f, (train_idx, eval_idx) in enumerate(folds):
+        M_tr, y_tr = M[train_idx], y[train_idx]
+        M_ev, y_ev = M[eval_idx], y[eval_idx]
+        E = M_tr.T @ M_tr
+        diag_add = np.asarray(
+            prior(fobj=None, E_tilda_lm=E, lmbda=lmbda), dtype=float
+        )
+        if diag_add.shape != (E.shape[0],):
+            raise ValueError(
+                f"prior returned diag of shape {diag_add.shape}; "
+                f"expected {(E.shape[0],)}"
+            )
+        np.fill_diagonal(E, np.diag(E) + diag_add)
+        rhs = M_tr.T @ y_tr
+        try:
+            c_factor, lower = la.cho_factor(E, lower=True, check_finite=False)
+            a_m = la.cho_solve((c_factor, lower), rhs, check_finite=False)
+        except la.LinAlgError:
+            a_m, *_ = np.linalg.lstsq(E, rhs, rcond=None)
+        y_pred = M_ev @ a_m
+        per_fold_mse[f] = float(np.mean((y_ev - y_pred) ** 2))
+        fold_sizes[f] = (int(train_idx.size), int(eval_idx.size))
+
+    return {
+        "per_fold_mse": per_fold_mse,
+        "mean_heldout_mse": float(np.mean(per_fold_mse)),
+        "fold_sizes": fold_sizes,
+    }
+
+
+__all__ = ["spatial_cv_score"]

--- a/pycsa/data/cell.py
+++ b/pycsa/data/cell.py
@@ -142,7 +142,8 @@ class topo_cell(topo):
         self.lat_m = self.lat_grid[self.mask]
         self.topo_m = self.topo[self.mask]
 
-        self.topo_m -= self.topo_m.mean()
+        self.topo_mean = float(self.topo_m.mean())
+        self.topo_m -= self.topo_mean
 
     def get_grad_topo(self, triangle) -> None:
         """Compute the topographic gradient.

--- a/pycsa/wrappers/interface.py
+++ b/pycsa/wrappers/interface.py
@@ -455,7 +455,7 @@ class second_appx(object):
     Use this routine to apply tapering and to separate the first and second approximation steps
     """
 
-    def __init__(self, nhi, nhj, params, topo, tri, ctx=None):
+    def __init__(self, nhi, nhj, params, topo, tri, ctx=None, selector=None):
         """
         Parameters
         ----------
@@ -472,6 +472,13 @@ class second_appx(object):
         ctx : ComputeContext, optional
             Compute context shared with the inner ``get_pmf`` call.
             Default-constructed if absent.
+        selector : :class:`pycsa.core.mode_selection.ModeSelector`, optional
+            Pluggable selector for the FA→SA mode-selection step. When
+            ``None`` (default), the existing inline greedy ``argmax``
+            loop is used and numerics are bit-identical to historical
+            behavior. If ``ctx.selector`` is set and this kwarg is
+            ``None``, the context's selector is used. Opt-in only; no
+            production caller passes this kwarg.
         """
         self.params = params
         self.topo = topo
@@ -479,6 +486,11 @@ class second_appx(object):
         self.nhi, self.nhj = nhi, nhj
         self.ctx = ctx
         self.n_modes = params.n_modes
+        # Resolve selector: explicit kwarg wins, then ctx-level fallback,
+        # otherwise stays None to take the preserved inline branch below.
+        if selector is None and ctx is not None:
+            selector = getattr(ctx, "selector", None)
+        self.selector = selector
 
     def do(self, idx, ampls_fa, res_topo=None, use_center=True):
         """Do the Second Approximation step
@@ -553,22 +565,39 @@ class second_appx(object):
             self.nhi, self.nhj, self.params.U, self.params.V, ctx=self.ctx
         )
 
-        indices = []
-        modes_cnt = 0
-        while modes_cnt < self.n_modes:
-            max_idx = np.unravel_index(fq_cpy.argmax(), fq_cpy.shape)
-            # skip the k = 0 column
-            # if max_idx[1] == 0:
-            #     fq_cpy[max_idx] = 0.0
-            # # else we want to use them
-            # else:
-            indices.append(max_idx)
-            fq_cpy[max_idx] = 0.0
-            modes_cnt += 1
+        if self.selector is None:
+            # Preserved inline branch — what every existing call site
+            # currently hits and what the reproducibility fixtures pin
+            # down. Bit-identical to historical behavior.
+            indices = []
+            modes_cnt = 0
+            while modes_cnt < self.n_modes:
+                max_idx = np.unravel_index(fq_cpy.argmax(), fq_cpy.shape)
+                # skip the k = 0 column
+                # if max_idx[1] == 0:
+                #     fq_cpy[max_idx] = 0.0
+                # # else we want to use them
+                # else:
+                indices.append(max_idx)
+                fq_cpy[max_idx] = 0.0
+                modes_cnt += 1
 
-        if not self.params.cg_spsp:
-            k_idxs = [pair[1] for pair in indices]
-            l_idxs = [pair[0] for pair in indices]
+            if not self.params.cg_spsp:
+                k_idxs = [pair[1] for pair in indices]
+                l_idxs = [pair[0] for pair in indices]
+        else:
+            # Opt-in: delegate to a pluggable ModeSelector. OMP / Lasso
+            # variants additionally need the design matrix; we leave
+            # building that to the selector (it can call
+            # ``second_guess.fobj.do_full(cell)`` + ``get_coeffs(fobj)``
+            # internally — the design-matrix construction is not yet
+            # threaded through here in the skeleton).
+            k_idxs, l_idxs = self.selector(
+                fq_cpy,
+                n_modes=self.n_modes,
+                design_matrix=None,
+                data=cell.topo_m,
+            )
 
         if self.params.dfft_first_guess:
             second_guess.fobj.set_kls(

--- a/runs/icon_etopo_global.py
+++ b/runs/icon_etopo_global.py
@@ -392,6 +392,7 @@ def do_cell(
             is_land,
             cell_sa.analysis,
             grid.cell_area[c_idx],
+            topo_mean=getattr(cell_sa, "topo_mean", None),
         )
 
         # Generate 3-panel plot

--- a/runs/icon_merit_global.py
+++ b/runs/icon_merit_global.py
@@ -143,7 +143,12 @@ def do_cell(
 
     # writer.output(c_idx, clat_rad[c_idx], clon_rad[c_idx], is_land, cell.analysis)
     result = writer.grp_struct(
-        c_idx, clat_rad[c_idx], clon_rad[c_idx], is_land, cell.analysis
+        c_idx,
+        clat_rad[c_idx],
+        clon_rad[c_idx],
+        is_land,
+        cell.analysis,
+        topo_mean=getattr(cell, "topo_mean", None),
     )
 
     if params.plot:

--- a/scripts/compare_baseline_vs_new_defaults.py
+++ b/scripts/compare_baseline_vs_new_defaults.py
@@ -69,7 +69,11 @@ def _build_south_pole_cell():
     """
     repo_root = Path(__file__).resolve().parents[1]
     fixture_dir = (
-        repo_root / "tests" / "reproducibility" / "fixtures" / "etopo_single_cell"
+        repo_root
+        / "tests"
+        / "reproducibility"
+        / "fixtures"
+        / "etopo_single_cell"
         / "input"
     )
     grid = var.grid()
@@ -109,26 +113,43 @@ def _fa_freqs(nhi, nhj, U, V, cell, lmbda_fa, prior=None):
     return np.asarray(freqs_fa)
 
 
-def _render(name, cell, ref_spec, ref_label,
-            dat_base, freqs_sa_base, l2_base,
-            dat_gcv, freqs_sa_gcv, l2_gcv, hp_gcv,
-            dat_spcv, freqs_sa_spcv, l2_spcv, hp_spcv,
-            out_dir):
+def _render(
+    name,
+    cell,
+    ref_spec,
+    ref_label,
+    dat_base,
+    freqs_sa_base,
+    l2_base,
+    dat_gcv,
+    freqs_sa_gcv,
+    l2_gcv,
+    hp_gcv,
+    dat_spcv,
+    freqs_sa_spcv,
+    l2_spcv,
+    hp_spcv,
+    out_dir,
+):
     """2×4 grid: original | baseline | new (GCV) | new (SpatialCV)."""
     fig, axs = plt.subplots(2, 4, figsize=(18, 8))
 
     topo_panels = [
         (cell.topo, "original topography"),
         (dat_base, "baseline SA reconstruction"),
-        (dat_gcv,  f"new (SA-GCV)  α={hp_gcv.alpha:.2f}, λ={hp_gcv.lmbda:.2e}"),
+        (dat_gcv, f"new (SA-GCV)  α={hp_gcv.alpha:.2f}, λ={hp_gcv.lmbda:.2e}"),
         (dat_spcv, f"new (SA-SpatialCV)  α={hp_spcv.alpha:.2f}, λ={hp_spcv.lmbda:.2e}"),
     ]
     topo_arrays = [np.nan_to_num(np.asarray(a)) for a, _ in topo_panels]
     topo_vmax = float(np.nanmax([np.nanmax(np.abs(a)) for a in topo_arrays])) or 1.0
     for col, ((_, title), arr) in enumerate(zip(topo_panels, topo_arrays)):
         im = axs[0, col].imshow(
-            arr, origin="lower", aspect="auto", cmap="terrain",
-            vmin=-topo_vmax, vmax=topo_vmax,
+            arr,
+            origin="lower",
+            aspect="auto",
+            cmap="terrain",
+            vmin=-topo_vmax,
+            vmax=topo_vmax,
         )
         axs[0, col].set_title(title, fontsize=10)
         axs[0, col].set_xlabel("lon index")
@@ -136,17 +157,21 @@ def _render(name, cell, ref_spec, ref_label,
         plt.colorbar(im, ax=axs[0, col], fraction=0.046, pad=0.04)
 
     spec_panels = [
-        (ref_spec,      f"{ref_label}"),
+        (ref_spec, f"{ref_label}"),
         (freqs_sa_base, f"baseline SA  L₂={l2_base:.2f}"),
-        (freqs_sa_gcv,  f"new (SA-GCV) SA  L₂={l2_gcv:.2f}"),
+        (freqs_sa_gcv, f"new (SA-GCV) SA  L₂={l2_gcv:.2f}"),
         (freqs_sa_spcv, f"new (SA-SpatialCV) SA  L₂={l2_spcv:.2f}"),
     ]
     spec_arrays = [np.nan_to_num(np.asarray(a)) for a, _ in spec_panels]
     spec_vmax = float(np.nanmax([np.nanmax(np.abs(a)) for a in spec_arrays])) or 1.0
     for col, ((_, title), arr) in enumerate(zip(spec_panels, spec_arrays)):
         im = axs[1, col].imshow(
-            arr, origin="lower", aspect="auto", cmap="viridis",
-            vmin=0.0, vmax=spec_vmax,
+            arr,
+            origin="lower",
+            aspect="auto",
+            cmap="viridis",
+            vmin=0.0,
+            vmax=spec_vmax,
         )
         axs[1, col].set_title(title, fontsize=10)
         axs[1, col].set_xlabel("k")
@@ -155,7 +180,8 @@ def _render(name, cell, ref_spec, ref_label,
 
     fig.suptitle(
         f"{name}: baseline vs new defaults  (SA-stage λ via GCV vs SpatialCV)",
-        fontsize=12, y=1.0,
+        fontsize=12,
+        y=1.0,
     )
     fig.tight_layout()
     out_path = out_dir / f"{name}_baseline_vs_new.png"
@@ -165,25 +191,51 @@ def _render(name, cell, ref_spec, ref_label,
 
 
 def _run(
-    name, cell, nhi, nhj, U, V, lmbda_fa_base, lmbda_sa_base, n_modes,
-    truth_freqs=None, remask_for_sa=None,
+    name,
+    cell,
+    nhi,
+    nhj,
+    U,
+    V,
+    lmbda_fa_base,
+    lmbda_sa_base,
+    n_modes,
+    truth_freqs=None,
+    remask_for_sa=None,
 ):
     print(f"\n=== {name} ===")
 
     # Baseline pipeline (production defaults). Provides the mode set
     # we re-use for both new-default pipelines below.
     _, freqs_sa_base, dat_base, k_idxs, l_idxs = _run_fa_sa(
-        nhi, nhj, U, V, cell,
-        lmbda_fa=lmbda_fa_base, lmbda_sa=lmbda_sa_base, n_modes=n_modes,
-        prior=None, remask_for_sa=remask_for_sa,
+        nhi,
+        nhj,
+        U,
+        V,
+        cell,
+        lmbda_fa=lmbda_fa_base,
+        lmbda_sa=lmbda_sa_base,
+        n_modes=n_modes,
+        prior=None,
+        remask_for_sa=remask_for_sa,
     )
 
     # SA-stage λ via two different selectors.
     hp_gcv = _pick_sa_lambda_via_gcv(
-        cell, nhi, nhj, k_idxs, l_idxs, remask_for_sa=remask_for_sa,
+        cell,
+        nhi,
+        nhj,
+        k_idxs,
+        l_idxs,
+        remask_for_sa=remask_for_sa,
     )
     hp_spcv = _pick_sa_lambda_via_spatial_cv(
-        cell, nhi, nhj, k_idxs, l_idxs, remask_for_sa=remask_for_sa,
+        cell,
+        nhi,
+        nhj,
+        k_idxs,
+        l_idxs,
+        remask_for_sa=remask_for_sa,
     )
     print(f"  SA-stage GCV pick:        α={hp_gcv.alpha:.3f}, λ={hp_gcv.lmbda:.3e}")
     print(f"  SA-stage SpatialCV pick:  α={hp_spcv.alpha:.3f}, λ={hp_spcv.lmbda:.3e}")
@@ -191,28 +243,60 @@ def _run(
 
     # Run both new-defaults pipelines.
     _, freqs_sa_gcv, dat_gcv, k_gcv, l_gcv = _run_fa_sa(
-        nhi, nhj, U, V, cell,
-        lmbda_fa=lmbda_fa_base, lmbda_sa=hp_gcv.lmbda, n_modes=n_modes,
-        prior=hp_gcv.prior, remask_for_sa=remask_for_sa,
+        nhi,
+        nhj,
+        U,
+        V,
+        cell,
+        lmbda_fa=lmbda_fa_base,
+        lmbda_sa=hp_gcv.lmbda,
+        n_modes=n_modes,
+        prior=hp_gcv.prior,
+        remask_for_sa=remask_for_sa,
     )
     _, freqs_sa_spcv, dat_spcv, k_spcv, l_spcv = _run_fa_sa(
-        nhi, nhj, U, V, cell,
-        lmbda_fa=lmbda_fa_base, lmbda_sa=hp_spcv.lmbda, n_modes=n_modes,
-        prior=hp_spcv.prior, remask_for_sa=remask_for_sa,
+        nhi,
+        nhj,
+        U,
+        V,
+        cell,
+        lmbda_fa=lmbda_fa_base,
+        lmbda_sa=hp_spcv.lmbda,
+        n_modes=n_modes,
+        prior=hp_spcv.prior,
+        remask_for_sa=remask_for_sa,
     )
 
     # 4-fold spatial holdout MSE for each pipeline.
     mse_base, _ = _holdout_sa_mse(
-        cell, nhi, nhj, k_idxs, l_idxs,
-        prior=None, lmbda_sa=lmbda_sa_base, remask_for_sa=remask_for_sa,
+        cell,
+        nhi,
+        nhj,
+        k_idxs,
+        l_idxs,
+        prior=None,
+        lmbda_sa=lmbda_sa_base,
+        remask_for_sa=remask_for_sa,
     )
     mse_gcv, _ = _holdout_sa_mse(
-        cell, nhi, nhj, k_gcv, l_gcv,
-        prior=hp_gcv.prior, lmbda_sa=hp_gcv.lmbda, remask_for_sa=remask_for_sa,
+        cell,
+        nhi,
+        nhj,
+        k_gcv,
+        l_gcv,
+        prior=hp_gcv.prior,
+        lmbda_sa=hp_gcv.lmbda,
+        remask_for_sa=remask_for_sa,
     )
     mse_spcv, _ = _holdout_sa_mse(
-        cell, nhi, nhj, k_spcv, l_spcv,
-        prior=hp_spcv.prior, lmbda_sa=hp_spcv.lmbda, remask_for_sa=remask_for_sa,
+        cell,
+        nhi,
+        nhj,
+        k_spcv,
+        l_spcv,
+        prior=hp_spcv.prior,
+        lmbda_sa=hp_spcv.lmbda,
+        remask_for_sa=remask_for_sa,
     )
     print(f"  SA-stage holdout MSE:")
     print(f"    baseline       = {mse_base:.3e}")
@@ -238,14 +322,27 @@ def _run(
     l2_base = float(np.linalg.norm(np.nan_to_num(freqs_sa_base) - ref_clean))
     l2_gcv = float(np.linalg.norm(np.nan_to_num(freqs_sa_gcv) - ref_clean))
     l2_spcv = float(np.linalg.norm(np.nan_to_num(freqs_sa_spcv) - ref_clean))
-    print(f"  L₂(SA, ref): "
-          f"baseline={l2_base:.3f}, GCV={l2_gcv:.3f}, SpatialCV={l2_spcv:.3f}")
+    print(
+        f"  L₂(SA, ref): "
+        f"baseline={l2_base:.3f}, GCV={l2_gcv:.3f}, SpatialCV={l2_spcv:.3f}"
+    )
 
     out_path = _render(
-        name, cell, ref, ref_label,
-        dat_base, freqs_sa_base, l2_base,
-        dat_gcv, freqs_sa_gcv, l2_gcv, hp_gcv,
-        dat_spcv, freqs_sa_spcv, l2_spcv, hp_spcv,
+        name,
+        cell,
+        ref,
+        ref_label,
+        dat_base,
+        freqs_sa_base,
+        l2_base,
+        dat_gcv,
+        freqs_sa_gcv,
+        l2_gcv,
+        hp_gcv,
+        dat_spcv,
+        freqs_sa_spcv,
+        l2_spcv,
+        hp_spcv,
         OUTPUT_DIR,
     )
     print(f"  figure: {out_path.relative_to(out_path.parents[2])}")
@@ -255,24 +352,36 @@ def main():
     print("Baseline vs new-defaults reference figures")
     print("------------------------------------------")
 
-    cell_id, _triangle, remask_id = _build_idealised_cell(
-        nhi=12, nhj=12, seed=777
-    )
+    cell_id, _triangle, remask_id = _build_idealised_cell(nhi=12, nhj=12, seed=777)
     truth = _build_idealised_freqs_ref(nhi=12, nhj=12, seed=777)
     _run(
-        "idealised", cell_id,
-        nhi=12, nhj=12, U=1.0, V=1.0,
-        lmbda_fa_base=1.0e-1, lmbda_sa_base=1.0e-6, n_modes=14,
-        truth_freqs=truth, remask_for_sa=remask_id,
+        "idealised",
+        cell_id,
+        nhi=12,
+        nhj=12,
+        U=1.0,
+        V=1.0,
+        lmbda_fa_base=1.0e-1,
+        lmbda_sa_base=1.0e-6,
+        n_modes=14,
+        truth_freqs=truth,
+        remask_for_sa=remask_id,
     )
 
     try:
         cell_al, remask_al = _build_aleutians_cell()
         _run(
-            "aleutians_merit", cell_al,
-            nhi=24, nhj=48, U=10.0, V=0.0,
-            lmbda_fa_base=0.0, lmbda_sa_base=1.0e-1, n_modes=50,
-            truth_freqs=None, remask_for_sa=remask_al,
+            "aleutians_merit",
+            cell_al,
+            nhi=24,
+            nhj=48,
+            U=10.0,
+            V=0.0,
+            lmbda_fa_base=0.0,
+            lmbda_sa_base=1.0e-1,
+            n_modes=50,
+            truth_freqs=None,
+            remask_for_sa=remask_al,
         )
     except Exception as exc:
         print(f"\naleutians_merit SKIPPED: {exc}")
@@ -280,10 +389,17 @@ def main():
     try:
         cell_sp, remask_sp = _build_south_pole_cell()
         _run(
-            "south_pole", cell_sp,
-            nhi=32, nhj=64, U=10.0, V=0.0,
-            lmbda_fa_base=0.0, lmbda_sa_base=1.0e-1, n_modes=100,
-            truth_freqs=None, remask_for_sa=remask_sp,
+            "south_pole",
+            cell_sp,
+            nhi=32,
+            nhj=64,
+            U=10.0,
+            V=0.0,
+            lmbda_fa_base=0.0,
+            lmbda_sa_base=1.0e-1,
+            n_modes=100,
+            truth_freqs=None,
+            remask_for_sa=remask_sp,
         )
     except Exception as exc:
         print(f"\nsouth_pole SKIPPED: {exc}")

--- a/scripts/compare_baseline_vs_new_defaults.py
+++ b/scripts/compare_baseline_vs_new_defaults.py
@@ -132,6 +132,7 @@ def _render(
     out_dir,
 ):
     """2×4 grid: original | baseline | new (GCV) | new (SpatialCV)."""
+    out_dir.mkdir(parents=True, exist_ok=True)
     fig, axs = plt.subplots(2, 4, figsize=(18, 8))
 
     topo_panels = [

--- a/scripts/compare_baseline_vs_new_defaults.py
+++ b/scripts/compare_baseline_vs_new_defaults.py
@@ -51,13 +51,22 @@ from validate_hyperparam_defaults import (  # noqa: E402
     _build_aleutians_cell,
     _build_idealised_cell,
     _build_idealised_freqs_ref,
+    _holdout_sa_mse,
     _materialize_design_matrix,
+    _pick_sa_lambda_via_gcv,
+    _pick_sa_lambda_via_spatial_cv,
     _run_fa_sa,
 )
+from pycsa.core.priors import IsotropicPrior  # noqa: E402
 
 
 def _build_south_pole_cell():
-    """Load the bundled ETOPO single-cell fixture (the polar cell)."""
+    """Load the bundled ETOPO single-cell fixture (the polar cell).
+
+    Returns ``(cell, remask_for_sa)``. Cell is built with ``rect=True``
+    so FA runs on the rectangular cover; ``remask_for_sa`` switches
+    it to the triangle-masked state for SA.
+    """
     repo_root = Path(__file__).resolve().parents[1]
     fixture_dir = (
         repo_root / "tests" / "reproducibility" / "fixtures" / "etopo_single_cell"
@@ -83,11 +92,15 @@ def _build_south_pole_cell():
     topo.gen_mgrids()
     cell = var.topo_cell()
     utils.get_lat_lon_segments(clat_verts, clon_verts, cell, topo, rect=True)
-    return cell
+
+    def remask_for_sa(c):
+        utils.get_lat_lon_segments(clat_verts, clon_verts, c, topo, rect=False)
+
+    return cell, remask_for_sa
 
 
 def _fa_freqs(nhi, nhj, U, V, cell, lmbda_fa, prior=None):
-    """Run FA only and return ``freqs_fa`` (the dense Fourier amplitudes)."""
+    """Run FA on the rectangular-cover ``cell`` and return ``freqs_fa``."""
     work_cell = deepcopy(cell)
     first_guess = interface.get_pmf(nhi, nhj, U, V)
     if prior is not None:
@@ -96,18 +109,19 @@ def _fa_freqs(nhi, nhj, U, V, cell, lmbda_fa, prior=None):
     return np.asarray(freqs_fa)
 
 
-def _render(name, cell, ref_spec, dat_base, freqs_sa_base, dat_new,
-            freqs_sa_new, hp_joint, l2_base, l2_new, ref_label, out_dir):
-    fig, axs = plt.subplots(2, 3, figsize=(13, 7))
+def _render(name, cell, ref_spec, ref_label,
+            dat_base, freqs_sa_base, l2_base,
+            dat_gcv, freqs_sa_gcv, l2_gcv, hp_gcv,
+            dat_spcv, freqs_sa_spcv, l2_spcv, hp_spcv,
+            out_dir):
+    """2×4 grid: original | baseline | new (GCV) | new (SpatialCV)."""
+    fig, axs = plt.subplots(2, 4, figsize=(18, 8))
 
-    # Top row: physical-domain reconstructions
     topo_panels = [
         (cell.topo, "original topography"),
         (dat_base, "baseline SA reconstruction"),
-        (
-            dat_new,
-            f"new defaults SA  (α={hp_joint.alpha:.2f}, λ={hp_joint.lmbda:.2e})",
-        ),
+        (dat_gcv,  f"new (SA-GCV)  α={hp_gcv.alpha:.2f}, λ={hp_gcv.lmbda:.2e}"),
+        (dat_spcv, f"new (SA-SpatialCV)  α={hp_spcv.alpha:.2f}, λ={hp_spcv.lmbda:.2e}"),
     ]
     topo_arrays = [np.nan_to_num(np.asarray(a)) for a, _ in topo_panels]
     topo_vmax = float(np.nanmax([np.nanmax(np.abs(a)) for a in topo_arrays])) or 1.0
@@ -116,17 +130,16 @@ def _render(name, cell, ref_spec, dat_base, freqs_sa_base, dat_new,
             arr, origin="lower", aspect="auto", cmap="terrain",
             vmin=-topo_vmax, vmax=topo_vmax,
         )
-        axs[0, col].set_title(title)
+        axs[0, col].set_title(title, fontsize=10)
         axs[0, col].set_xlabel("lon index")
         axs[0, col].set_ylabel("lat index")
         plt.colorbar(im, ax=axs[0, col], fraction=0.046, pad=0.04)
 
-    # Bottom row: spectra — shared color scale across all three panels
-    # so visual differences mean amplitude differences, not rescales.
     spec_panels = [
-        (ref_spec, f"{ref_label}"),
-        (freqs_sa_base, f"baseline SA spectrum  (L₂={l2_base:.2f})"),
-        (freqs_sa_new, f"new defaults SA spectrum  (L₂={l2_new:.2f})"),
+        (ref_spec,      f"{ref_label}"),
+        (freqs_sa_base, f"baseline SA  L₂={l2_base:.2f}"),
+        (freqs_sa_gcv,  f"new (SA-GCV) SA  L₂={l2_gcv:.2f}"),
+        (freqs_sa_spcv, f"new (SA-SpatialCV) SA  L₂={l2_spcv:.2f}"),
     ]
     spec_arrays = [np.nan_to_num(np.asarray(a)) for a, _ in spec_panels]
     spec_vmax = float(np.nanmax([np.nanmax(np.abs(a)) for a in spec_arrays])) or 1.0
@@ -135,13 +148,13 @@ def _render(name, cell, ref_spec, dat_base, freqs_sa_base, dat_new,
             arr, origin="lower", aspect="auto", cmap="viridis",
             vmin=0.0, vmax=spec_vmax,
         )
-        axs[1, col].set_title(title)
+        axs[1, col].set_title(title, fontsize=10)
         axs[1, col].set_xlabel("k")
         axs[1, col].set_ylabel("l")
         plt.colorbar(im, ax=axs[1, col], fraction=0.046, pad=0.04)
 
     fig.suptitle(
-        f"{name}: baseline vs new defaults  (joint-GCV + Greedy)",
+        f"{name}: baseline vs new defaults  (SA-stage λ via GCV vs SpatialCV)",
         fontsize=12, y=1.0,
     )
     fig.tight_layout()
@@ -153,50 +166,87 @@ def _render(name, cell, ref_spec, dat_base, freqs_sa_base, dat_new,
 
 def _run(
     name, cell, nhi, nhj, U, V, lmbda_fa_base, lmbda_sa_base, n_modes,
-    truth_freqs=None,
+    truth_freqs=None, remask_for_sa=None,
 ):
     print(f"\n=== {name} ===")
-    M = _materialize_design_matrix(nhi, nhj, cell)
-    hp = build_spectral_prior(
-        topography=cell.topo, design_matrix=M, data=cell.topo_m,
-        joint_selector=JointGCVSelector(),
-    )
-    print(f"  joint-GCV pick: α={hp.alpha:.3f}, λ={hp.lmbda:.3e}")
 
-    _, freqs_sa_base, dat_base, _, _ = _run_fa_sa(
+    # Baseline pipeline (production defaults). Provides the mode set
+    # we re-use for both new-default pipelines below.
+    _, freqs_sa_base, dat_base, k_idxs, l_idxs = _run_fa_sa(
         nhi, nhj, U, V, cell,
         lmbda_fa=lmbda_fa_base, lmbda_sa=lmbda_sa_base, n_modes=n_modes,
-        prior=None,
+        prior=None, remask_for_sa=remask_for_sa,
     )
-    _, freqs_sa_new, dat_new, _, _ = _run_fa_sa(
+
+    # SA-stage λ via two different selectors.
+    hp_gcv = _pick_sa_lambda_via_gcv(
+        cell, nhi, nhj, k_idxs, l_idxs, remask_for_sa=remask_for_sa,
+    )
+    hp_spcv = _pick_sa_lambda_via_spatial_cv(
+        cell, nhi, nhj, k_idxs, l_idxs, remask_for_sa=remask_for_sa,
+    )
+    print(f"  SA-stage GCV pick:        α={hp_gcv.alpha:.3f}, λ={hp_gcv.lmbda:.3e}")
+    print(f"  SA-stage SpatialCV pick:  α={hp_spcv.alpha:.3f}, λ={hp_spcv.lmbda:.3e}")
+    print(f"  production hardcoded λ_sa = {lmbda_sa_base:.3e}")
+
+    # Run both new-defaults pipelines.
+    _, freqs_sa_gcv, dat_gcv, k_gcv, l_gcv = _run_fa_sa(
         nhi, nhj, U, V, cell,
-        lmbda_fa=hp.lmbda, lmbda_sa=hp.lmbda, n_modes=n_modes, prior=hp.prior,
+        lmbda_fa=lmbda_fa_base, lmbda_sa=hp_gcv.lmbda, n_modes=n_modes,
+        prior=hp_gcv.prior, remask_for_sa=remask_for_sa,
     )
+    _, freqs_sa_spcv, dat_spcv, k_spcv, l_spcv = _run_fa_sa(
+        nhi, nhj, U, V, cell,
+        lmbda_fa=lmbda_fa_base, lmbda_sa=hp_spcv.lmbda, n_modes=n_modes,
+        prior=hp_spcv.prior, remask_for_sa=remask_for_sa,
+    )
+
+    # 4-fold spatial holdout MSE for each pipeline.
+    mse_base, _ = _holdout_sa_mse(
+        cell, nhi, nhj, k_idxs, l_idxs,
+        prior=None, lmbda_sa=lmbda_sa_base, remask_for_sa=remask_for_sa,
+    )
+    mse_gcv, _ = _holdout_sa_mse(
+        cell, nhi, nhj, k_gcv, l_gcv,
+        prior=hp_gcv.prior, lmbda_sa=hp_gcv.lmbda, remask_for_sa=remask_for_sa,
+    )
+    mse_spcv, _ = _holdout_sa_mse(
+        cell, nhi, nhj, k_spcv, l_spcv,
+        prior=hp_spcv.prior, lmbda_sa=hp_spcv.lmbda, remask_for_sa=remask_for_sa,
+    )
+    print(f"  SA-stage holdout MSE:")
+    print(f"    baseline       = {mse_base:.3e}")
+    rel_gcv = (mse_base - mse_gcv) / mse_base * 100.0
+    rel_spcv = (mse_base - mse_spcv) / mse_base * 100.0
+    print(f"    new (GCV)      = {mse_gcv:.3e}   ({rel_gcv:+.2f}% vs baseline)")
+    print(f"    new (SpatialCV)= {mse_spcv:.3e}   ({rel_spcv:+.2f}% vs baseline)")
 
     if truth_freqs is not None:
         ref = np.asarray(truth_freqs)
         ref_label = "reference spectrum (planted truth, L₂=0)"
     else:
-        ref = _fa_freqs(nhi, nhj, U, V, cell, hp.lmbda, hp.prior)
-        ref_label = "FA spectrum (dense, new-defaults run) — reference"
+        # Dense reference: the unregularized FA spectrum (λ_fa=0, no
+        # prior — production's FA stage, unchanged across pipelines).
+        # The SA panels are sparse approximations of this.
+        ref = _fa_freqs(nhi, nhj, U, V, cell, lmbda_fa_base, None)
+        ref_label = "FA spectrum (dense, λ_fa=0) — reference"
 
     # FA / SA spectra come back with NaN sentinels at unused half-grid
     # entries (see fourier.f_trans.get_freq_grid); clean them before
     # taking the norm so a single NaN doesn't poison the whole metric.
-    base_clean = np.nan_to_num(freqs_sa_base)
-    new_clean = np.nan_to_num(freqs_sa_new)
     ref_clean = np.nan_to_num(ref)
-    l2_base = float(np.linalg.norm(base_clean - ref_clean))
-    l2_new = float(np.linalg.norm(new_clean - ref_clean))
-    verdict = (
-        "new wins" if l2_new < l2_base
-        else "baseline wins" if l2_new > l2_base else "tie"
-    )
-    print(f"  L₂(SA, ref): baseline={l2_base:.3f}, new={l2_new:.3f}  ({verdict})")
+    l2_base = float(np.linalg.norm(np.nan_to_num(freqs_sa_base) - ref_clean))
+    l2_gcv = float(np.linalg.norm(np.nan_to_num(freqs_sa_gcv) - ref_clean))
+    l2_spcv = float(np.linalg.norm(np.nan_to_num(freqs_sa_spcv) - ref_clean))
+    print(f"  L₂(SA, ref): "
+          f"baseline={l2_base:.3f}, GCV={l2_gcv:.3f}, SpatialCV={l2_spcv:.3f}")
 
     out_path = _render(
-        name, cell, ref, dat_base, freqs_sa_base, dat_new, freqs_sa_new,
-        hp, l2_base, l2_new, ref_label, OUTPUT_DIR,
+        name, cell, ref, ref_label,
+        dat_base, freqs_sa_base, l2_base,
+        dat_gcv, freqs_sa_gcv, l2_gcv, hp_gcv,
+        dat_spcv, freqs_sa_spcv, l2_spcv, hp_spcv,
+        OUTPUT_DIR,
     )
     print(f"  figure: {out_path.relative_to(out_path.parents[2])}")
 
@@ -205,33 +255,35 @@ def main():
     print("Baseline vs new-defaults reference figures")
     print("------------------------------------------")
 
-    cell_id, _ = _build_idealised_cell(nhi=12, nhj=12, seed=777)
+    cell_id, _triangle, remask_id = _build_idealised_cell(
+        nhi=12, nhj=12, seed=777
+    )
     truth = _build_idealised_freqs_ref(nhi=12, nhj=12, seed=777)
     _run(
         "idealised", cell_id,
         nhi=12, nhj=12, U=1.0, V=1.0,
         lmbda_fa_base=1.0e-1, lmbda_sa_base=1.0e-6, n_modes=14,
-        truth_freqs=truth,
+        truth_freqs=truth, remask_for_sa=remask_id,
     )
 
     try:
-        cell_al = _build_aleutians_cell()
+        cell_al, remask_al = _build_aleutians_cell()
         _run(
             "aleutians_merit", cell_al,
             nhi=24, nhj=48, U=10.0, V=0.0,
             lmbda_fa_base=0.0, lmbda_sa_base=1.0e-1, n_modes=50,
-            truth_freqs=None,
+            truth_freqs=None, remask_for_sa=remask_al,
         )
     except Exception as exc:
         print(f"\naleutians_merit SKIPPED: {exc}")
 
     try:
-        cell_sp = _build_south_pole_cell()
+        cell_sp, remask_sp = _build_south_pole_cell()
         _run(
             "south_pole", cell_sp,
             nhi=32, nhj=64, U=10.0, V=0.0,
             lmbda_fa_base=0.0, lmbda_sa_base=1.0e-1, n_modes=100,
-            truth_freqs=None,
+            truth_freqs=None, remask_for_sa=remask_sp,
         )
     except Exception as exc:
         print(f"\nsouth_pole SKIPPED: {exc}")

--- a/scripts/compare_baseline_vs_new_defaults.py
+++ b/scripts/compare_baseline_vs_new_defaults.py
@@ -1,0 +1,243 @@
+"""Reference figures comparing baseline vs the new-defaults pipeline.
+
+Produces one PR-#32-style 2×3 figure per fixture under
+``scripts/validate_outputs/<fixture>_baseline_vs_new.png``:
+
+    [ input topo            | baseline SA recon       | new-defaults SA recon       ]
+    [ reference spectrum    | baseline SA spectrum    | new-defaults SA spectrum    ]
+
+"New defaults" = ``build_spectral_prior(joint_selector=JointGCVSelector())``,
+with mode selection via greedy argmax (production default), applied
+uniformly at FA *and* SA. On every fixture tested so far the joint
+GCV picks ``α = 0`` (no per-mode structure), so the "new defaults"
+pipeline is in practice isotropic Tikhonov at a data-picked scalar
+``λ`` — but the script doesn't bake that in, so if a future cell
+benefits from ``α > 0`` it would surface here automatically.
+
+The "reference spectrum" panel is:
+
+- the planted-modes ground truth for ``idealised`` (a ``(nhar_j,
+  nhar_i)`` array with non-zero entries only at the planted
+  ``(l + 5, k)`` positions);
+- the FA spectrum from the new-defaults run for real-data fixtures
+  — the densest, least-biased estimate we have without a known
+  truth. The L₂ labels then read as "how much does the SA sparse
+  approximation deviate from the dense FA estimate."
+
+Run::
+
+    ~/anaconda3/envs/playground/bin/python scripts/compare_baseline_vs_new_defaults.py
+"""
+
+from __future__ import annotations
+
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+import netCDF4  # noqa: F401 — netCDF4 must be imported before pycsa.core.io
+import matplotlib.pyplot as plt
+import numpy as np
+
+from pycsa.core import fourier, lin_reg, utils, var
+from pycsa.core import io as pcio
+from pycsa.core.hyperparams import JointGCVSelector, build_spectral_prior
+from pycsa.wrappers import interface
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE))
+from validate_hyperparam_defaults import (  # noqa: E402
+    OUTPUT_DIR,
+    _build_aleutians_cell,
+    _build_idealised_cell,
+    _build_idealised_freqs_ref,
+    _materialize_design_matrix,
+    _run_fa_sa,
+)
+
+
+def _build_south_pole_cell():
+    """Load the bundled ETOPO single-cell fixture (the polar cell)."""
+    repo_root = Path(__file__).resolve().parents[1]
+    fixture_dir = (
+        repo_root / "tests" / "reproducibility" / "fixtures" / "etopo_single_cell"
+        / "input"
+    )
+    grid = var.grid()
+    pcio.ncdata().read_dat(str(fixture_dir / "icon_grid.nc"), grid)
+    lat_verts_orig = np.degrees(grid.clat_vertices[0])
+    lon_verts_orig = np.degrees(grid.clon_vertices[0])
+    clat_verts, clon_verts = utils.handle_latlon_expansion(
+        lat_verts_orig.copy(), lon_verts_orig.copy()
+    )
+    params = var.params()
+    params.path_etopo = str(fixture_dir / "etopo") + "/"
+    params.lat_extent = clat_verts
+    params.lon_extent = clon_verts
+    params.etopo_cg = 1
+    params.padding = 10
+    topo = var.topo_cell()
+    reader = pcio.ncdata(padding=params.padding, padding_tol=(60 - params.padding))
+    reader.read_etopo_topo(topo, params)
+    topo.topo[np.where(topo.topo < -500.0)] = -500.0
+    topo.gen_mgrids()
+    cell = var.topo_cell()
+    utils.get_lat_lon_segments(clat_verts, clon_verts, cell, topo, rect=True)
+    return cell
+
+
+def _fa_freqs(nhi, nhj, U, V, cell, lmbda_fa, prior=None):
+    """Run FA only and return ``freqs_fa`` (the dense Fourier amplitudes)."""
+    work_cell = deepcopy(cell)
+    first_guess = interface.get_pmf(nhi, nhj, U, V)
+    if prior is not None:
+        first_guess.ctx.prior = prior
+    freqs_fa, _, _ = first_guess.sappx(work_cell, lmbda=lmbda_fa)
+    return np.asarray(freqs_fa)
+
+
+def _render(name, cell, ref_spec, dat_base, freqs_sa_base, dat_new,
+            freqs_sa_new, hp_joint, l2_base, l2_new, ref_label, out_dir):
+    fig, axs = plt.subplots(2, 3, figsize=(13, 7))
+
+    # Top row: physical-domain reconstructions
+    topo_panels = [
+        (cell.topo, "original topography"),
+        (dat_base, "baseline SA reconstruction"),
+        (
+            dat_new,
+            f"new defaults SA  (α={hp_joint.alpha:.2f}, λ={hp_joint.lmbda:.2e})",
+        ),
+    ]
+    topo_arrays = [np.nan_to_num(np.asarray(a)) for a, _ in topo_panels]
+    topo_vmax = float(np.nanmax([np.nanmax(np.abs(a)) for a in topo_arrays])) or 1.0
+    for col, ((_, title), arr) in enumerate(zip(topo_panels, topo_arrays)):
+        im = axs[0, col].imshow(
+            arr, origin="lower", aspect="auto", cmap="terrain",
+            vmin=-topo_vmax, vmax=topo_vmax,
+        )
+        axs[0, col].set_title(title)
+        axs[0, col].set_xlabel("lon index")
+        axs[0, col].set_ylabel("lat index")
+        plt.colorbar(im, ax=axs[0, col], fraction=0.046, pad=0.04)
+
+    # Bottom row: spectra — shared color scale across all three panels
+    # so visual differences mean amplitude differences, not rescales.
+    spec_panels = [
+        (ref_spec, f"{ref_label}"),
+        (freqs_sa_base, f"baseline SA spectrum  (L₂={l2_base:.2f})"),
+        (freqs_sa_new, f"new defaults SA spectrum  (L₂={l2_new:.2f})"),
+    ]
+    spec_arrays = [np.nan_to_num(np.asarray(a)) for a, _ in spec_panels]
+    spec_vmax = float(np.nanmax([np.nanmax(np.abs(a)) for a in spec_arrays])) or 1.0
+    for col, ((_, title), arr) in enumerate(zip(spec_panels, spec_arrays)):
+        im = axs[1, col].imshow(
+            arr, origin="lower", aspect="auto", cmap="viridis",
+            vmin=0.0, vmax=spec_vmax,
+        )
+        axs[1, col].set_title(title)
+        axs[1, col].set_xlabel("k")
+        axs[1, col].set_ylabel("l")
+        plt.colorbar(im, ax=axs[1, col], fraction=0.046, pad=0.04)
+
+    fig.suptitle(
+        f"{name}: baseline vs new defaults  (joint-GCV + Greedy)",
+        fontsize=12, y=1.0,
+    )
+    fig.tight_layout()
+    out_path = out_dir / f"{name}_baseline_vs_new.png"
+    fig.savefig(out_path, dpi=120, bbox_inches="tight")
+    plt.close(fig)
+    return out_path
+
+
+def _run(
+    name, cell, nhi, nhj, U, V, lmbda_fa_base, lmbda_sa_base, n_modes,
+    truth_freqs=None,
+):
+    print(f"\n=== {name} ===")
+    M = _materialize_design_matrix(nhi, nhj, cell)
+    hp = build_spectral_prior(
+        topography=cell.topo, design_matrix=M, data=cell.topo_m,
+        joint_selector=JointGCVSelector(),
+    )
+    print(f"  joint-GCV pick: α={hp.alpha:.3f}, λ={hp.lmbda:.3e}")
+
+    _, freqs_sa_base, dat_base, _, _ = _run_fa_sa(
+        nhi, nhj, U, V, cell,
+        lmbda_fa=lmbda_fa_base, lmbda_sa=lmbda_sa_base, n_modes=n_modes,
+        prior=None,
+    )
+    _, freqs_sa_new, dat_new, _, _ = _run_fa_sa(
+        nhi, nhj, U, V, cell,
+        lmbda_fa=hp.lmbda, lmbda_sa=hp.lmbda, n_modes=n_modes, prior=hp.prior,
+    )
+
+    if truth_freqs is not None:
+        ref = np.asarray(truth_freqs)
+        ref_label = "reference spectrum (planted truth, L₂=0)"
+    else:
+        ref = _fa_freqs(nhi, nhj, U, V, cell, hp.lmbda, hp.prior)
+        ref_label = "FA spectrum (dense, new-defaults run) — reference"
+
+    # FA / SA spectra come back with NaN sentinels at unused half-grid
+    # entries (see fourier.f_trans.get_freq_grid); clean them before
+    # taking the norm so a single NaN doesn't poison the whole metric.
+    base_clean = np.nan_to_num(freqs_sa_base)
+    new_clean = np.nan_to_num(freqs_sa_new)
+    ref_clean = np.nan_to_num(ref)
+    l2_base = float(np.linalg.norm(base_clean - ref_clean))
+    l2_new = float(np.linalg.norm(new_clean - ref_clean))
+    verdict = (
+        "new wins" if l2_new < l2_base
+        else "baseline wins" if l2_new > l2_base else "tie"
+    )
+    print(f"  L₂(SA, ref): baseline={l2_base:.3f}, new={l2_new:.3f}  ({verdict})")
+
+    out_path = _render(
+        name, cell, ref, dat_base, freqs_sa_base, dat_new, freqs_sa_new,
+        hp, l2_base, l2_new, ref_label, OUTPUT_DIR,
+    )
+    print(f"  figure: {out_path.relative_to(out_path.parents[2])}")
+
+
+def main():
+    print("Baseline vs new-defaults reference figures")
+    print("------------------------------------------")
+
+    cell_id, _ = _build_idealised_cell(nhi=12, nhj=12, seed=777)
+    truth = _build_idealised_freqs_ref(nhi=12, nhj=12, seed=777)
+    _run(
+        "idealised", cell_id,
+        nhi=12, nhj=12, U=1.0, V=1.0,
+        lmbda_fa_base=1.0e-1, lmbda_sa_base=1.0e-6, n_modes=14,
+        truth_freqs=truth,
+    )
+
+    try:
+        cell_al = _build_aleutians_cell()
+        _run(
+            "aleutians_merit", cell_al,
+            nhi=24, nhj=48, U=10.0, V=0.0,
+            lmbda_fa_base=0.0, lmbda_sa_base=1.0e-1, n_modes=50,
+            truth_freqs=None,
+        )
+    except Exception as exc:
+        print(f"\naleutians_merit SKIPPED: {exc}")
+
+    try:
+        cell_sp = _build_south_pole_cell()
+        _run(
+            "south_pole", cell_sp,
+            nhi=32, nhj=64, U=10.0, V=0.0,
+            lmbda_fa_base=0.0, lmbda_sa_base=1.0e-1, n_modes=100,
+            truth_freqs=None,
+        )
+    except Exception as exc:
+        print(f"\nsouth_pole SKIPPED: {exc}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_cells_of_interest.py
+++ b/scripts/validate_cells_of_interest.py
@@ -1,0 +1,269 @@
+"""One-off cells-of-interest validation for the kernel-spike defaults.
+
+Runs the same 3-way prior comparison (baseline / isotropic@λ_GCV /
+SpectralPrior@λ_GCV) and the same 3-way selector comparison
+(Greedy / OMP / Lasso) as ``scripts/validate_hyperparam_defaults.py``,
+but on **named real-data cells** picked from an ICON grid using
+**ETOPO** topography (not MERIT — MERIT is regional and doesn't cover
+Himalayas / Andes / Greenland / etc.).
+
+Not part of CI. Run it by hand when you want to see how the structured
+prior and the sparsity-inducing selectors behave on orographically
+interesting regions.
+
+Usage::
+
+    ~/anaconda3/envs/playground/bin/python scripts/validate_cells_of_interest.py \\
+        --icon-grid /path/to/icon_grid.nc \\
+        --etopo-dir /path/to/etopo/tiles/
+
+Add ``--regions himalayas andes`` to subset. Without ``--icon-grid``
+and ``--etopo-dir`` the script falls back to the bundled
+``tests/reproducibility/fixtures/etopo_single_cell`` (single polar
+cell only — useful for end-to-end smoke testing of the script).
+
+Each region produces:
+
+- a tabular summary line with α (slope + stderr + R²), λ_GCV, the
+  improvement vs. baseline under isotropic-at-λ and SpectralPrior-at-λ,
+  and the structure-only contribution; then
+- a 4-panel topography plot (input | baseline | isotropic | selected)
+  in ``scripts/validate_outputs/<region>_reconstruction.png``;
+- a 4-panel selector plot (input | Greedy | OMP | Lasso) in
+  ``scripts/validate_outputs/<region>_selectors_reconstruction.png``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+# netCDF4 must be imported before pycsa.core.io per the playground env quirk.
+import netCDF4  # noqa: F401
+import numpy as np
+
+from pycsa.core import io as pcio, utils, var
+
+# Reuse the validation helpers from the sibling script.
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE))
+from validate_hyperparam_defaults import (  # noqa: E402
+    _diagnose,
+    _selector_compare,
+    OUTPUT_DIR,
+)
+
+
+# ----------------------------------------------------------------------
+# Region catalog
+# ----------------------------------------------------------------------
+#
+# (lat, lon) centers in degrees. These are *targets*; the script picks
+# the ICON cell whose centroid is closest to each target. Add or
+# override on the CLI with --regions.
+
+REGIONS = {
+    "aleutians":         ( 52.0, -175.0),
+    "himalayas":         ( 28.0,   87.0),
+    "andes":             (-22.0,  -68.0),
+    "alps":              ( 46.5,    8.5),
+    "greenland":         ( 72.0,  -40.0),
+    "east_african_rift": (  0.5,   36.0),
+    "pacific_nw":        ( 47.0, -123.0),
+    "south_pole":        (-89.0,    0.0),
+}
+
+# Production-baseline parameters reused across cells (mirror the
+# Aleutians MERIT fixture's lmbda choices and the ETOPO single-cell
+# fixture's NHI/NHJ). Real cells may want per-region tuning; for the
+# one-off check we keep one set of numbers so cross-cell comparison
+# is apples-to-apples.
+NHI, NHJ = 32, 64
+N_MODES = 100
+LMBDA_FA = 0.0
+LMBDA_SA = 1.0e-1
+U, V = 10.0, 0.0
+PADDING = 10
+
+
+# ----------------------------------------------------------------------
+# Grid + ETOPO loaders
+# ----------------------------------------------------------------------
+
+
+def _great_circle_distance(lat1, lon1, lat2, lon2):
+    """Great-circle distance (radians) between two (lat, lon) points in degrees."""
+    a1 = np.deg2rad(lat1); o1 = np.deg2rad(lon1)
+    a2 = np.deg2rad(lat2); o2 = np.deg2rad(lon2)
+    return np.arccos(
+        np.clip(
+            np.sin(a1) * np.sin(a2) + np.cos(a1) * np.cos(a2) * np.cos(o2 - o1),
+            -1.0, 1.0,
+        )
+    )
+
+
+def _find_nearest_cell(grid, lat_deg, lon_deg) -> int:
+    """Return the ICON cell index whose centroid is closest to (lat, lon)."""
+    clat = np.degrees(np.asarray(grid.clat))
+    clon = np.degrees(np.asarray(grid.clon))
+    d = _great_circle_distance(lat_deg, lon_deg, clat, clon)
+    return int(np.argmin(d))
+
+
+def _build_cell_from_etopo(grid, cell_idx: int, etopo_dir: str, etopo_cg: int = 1):
+    """Construct a CSA ``topo_cell`` for ICON cell ``cell_idx`` using ETOPO data.
+
+    Mirrors the load path in
+    ``tests/reproducibility/capture/capture_etopo_single_cell._run_pipeline``.
+    """
+    lat_verts_orig = np.degrees(grid.clat_vertices[cell_idx])
+    lon_verts_orig = np.degrees(grid.clon_vertices[cell_idx])
+    clat_verts, clon_verts = utils.handle_latlon_expansion(
+        lat_verts_orig.copy(), lon_verts_orig.copy()
+    )
+
+    params = var.params()
+    params.path_etopo = etopo_dir if etopo_dir.endswith("/") else etopo_dir + "/"
+    params.lat_extent = clat_verts
+    params.lon_extent = clon_verts
+    params.etopo_cg = etopo_cg
+    params.padding = PADDING
+
+    topo = var.topo_cell()
+    reader = pcio.ncdata(padding=params.padding, padding_tol=(60 - params.padding))
+    reader.read_etopo_topo(topo, params)
+    topo.topo[np.where(topo.topo < -500.0)] = -500.0
+    topo.gen_mgrids()
+
+    cell = var.topo_cell()
+    utils.get_lat_lon_segments(clat_verts, clon_verts, cell, topo, rect=True)
+    return cell, clat_verts, clon_verts
+
+
+# ----------------------------------------------------------------------
+# Per-region runner
+# ----------------------------------------------------------------------
+
+
+def _run_region(name, grid, etopo_dir: str, etopo_cg: int):
+    lat_deg, lon_deg = REGIONS[name]
+    cell_idx = _find_nearest_cell(grid, lat_deg, lon_deg)
+    clat_deg = float(np.degrees(grid.clat[cell_idx]))
+    clon_deg = float(np.degrees(grid.clon[cell_idx]))
+    print(f"\n========================================")
+    print(f"region: {name}")
+    print(f"  target  (lat, lon) = ({lat_deg:.2f}°, {lon_deg:.2f}°)")
+    print(f"  nearest cell idx   = {cell_idx}  centroid = "
+          f"({clat_deg:.2f}°, {clon_deg:.2f}°)")
+    try:
+        cell, *_ = _build_cell_from_etopo(grid, cell_idx, etopo_dir, etopo_cg)
+    except Exception as exc:
+        print(f"  ETOPO load failed: {exc} — SKIPPING")
+        return
+
+    # Reuse helpers from sibling validate script.
+    from pycsa.core.priors import IsotropicPrior  # local import to keep top tidy
+
+    # Prior comparison (3-way) at the production baseline.
+    result = _diagnose(
+        name, cell,
+        nhi=NHI, nhj=NHJ, U=U, V=V,
+        lmbda_fa=LMBDA_FA, lmbda_sa=LMBDA_SA, n_modes=N_MODES,
+        truth_freqs=None,  # no ground truth for real-data cells
+    )
+    # Selectors under the production regime, then under the
+    # isotropic-at-λ_GCV regime (the one that may be the empirical
+    # winner per cell). Side-by-side both lets the reader see whether
+    # selector preference flips with the regularization regime.
+    _selector_compare(
+        name, cell,
+        nhi=NHI, nhj=NHJ, U=U, V=V,
+        lmbda_fa=LMBDA_FA, lmbda_sa=LMBDA_SA, n_modes=N_MODES,
+        prior_for_compare=None, truth_freqs=None,
+    )
+    _selector_compare(
+        f"{name}_gcv", cell,
+        nhi=NHI, nhj=NHJ, U=U, V=V,
+        lmbda_fa=result["lambda"], lmbda_sa=result["lambda"], n_modes=N_MODES,
+        prior_for_compare=IsotropicPrior(), truth_freqs=None,
+    )
+
+
+# ----------------------------------------------------------------------
+# CLI
+# ----------------------------------------------------------------------
+
+
+def _parse_args(argv):
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument(
+        "--icon-grid",
+        type=str,
+        default=None,
+        help="Path to an ICON grid .nc file (e.g. R2B4). If omitted, falls back "
+             "to the bundled etopo_single_cell fixture grid (single polar cell only).",
+    )
+    p.add_argument(
+        "--etopo-dir",
+        type=str,
+        default=None,
+        help="Directory of ETOPO 15s NetCDF tiles. If omitted, uses the bundled "
+             "single-cell fixture tiles.",
+    )
+    p.add_argument(
+        "--etopo-cg",
+        type=int,
+        default=4,
+        help="ETOPO coarse-graining factor (default 4 = production). The "
+             "bundled fixture is pre-downsampled by 20× so the demo path "
+             "auto-sets this to 1.",
+    )
+    p.add_argument(
+        "--regions",
+        nargs="*",
+        default=list(REGIONS.keys()),
+        choices=list(REGIONS.keys()),
+        help="Subset of regions to run (default: all).",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv=None):
+    args = _parse_args(argv)
+    repo_root = Path(__file__).resolve().parents[1]
+
+    if args.icon_grid is None or args.etopo_dir is None:
+        print("No --icon-grid / --etopo-dir provided — falling back to bundled "
+              "etopo_single_cell fixture (single polar cell only).")
+        fixture_dir = repo_root / "tests" / "reproducibility" / "fixtures" / "etopo_single_cell" / "input"
+        icon_grid_path = str(fixture_dir / "icon_grid.nc")
+        etopo_dir = str(fixture_dir / "etopo")
+        etopo_cg = 1  # bundle is pre-downsampled
+        regions_to_run = ["south_pole"]
+    else:
+        icon_grid_path = args.icon_grid
+        etopo_dir = args.etopo_dir
+        etopo_cg = args.etopo_cg
+        regions_to_run = args.regions
+
+    grid = var.grid()
+    pcio.ncdata().read_dat(icon_grid_path, grid)
+    print(f"loaded ICON grid: {icon_grid_path}")
+    print(f"  n_cells = {len(grid.clat)}")
+    print(f"output dir for plots: {OUTPUT_DIR}")
+
+    for name in regions_to_run:
+        try:
+            _run_region(name, grid, etopo_dir, etopo_cg)
+        except Exception as exc:
+            print(f"\nregion {name} failed: {exc}")
+            import traceback
+            traceback.print_exc()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_cells_of_interest.py
+++ b/scripts/validate_cells_of_interest.py
@@ -55,7 +55,6 @@ from validate_hyperparam_defaults import (  # noqa: E402
     OUTPUT_DIR,
 )
 
-
 # ----------------------------------------------------------------------
 # Region catalog
 # ----------------------------------------------------------------------
@@ -65,14 +64,14 @@ from validate_hyperparam_defaults import (  # noqa: E402
 # override on the CLI with --regions.
 
 REGIONS = {
-    "aleutians":         ( 52.0, -175.0),
-    "himalayas":         ( 28.0,   87.0),
-    "andes":             (-22.0,  -68.0),
-    "alps":              ( 46.5,    8.5),
-    "greenland":         ( 72.0,  -40.0),
-    "east_african_rift": (  0.5,   36.0),
-    "pacific_nw":        ( 47.0, -123.0),
-    "south_pole":        (-89.0,    0.0),
+    "aleutians": (52.0, -175.0),
+    "himalayas": (28.0, 87.0),
+    "andes": (-22.0, -68.0),
+    "alps": (46.5, 8.5),
+    "greenland": (72.0, -40.0),
+    "east_african_rift": (0.5, 36.0),
+    "pacific_nw": (47.0, -123.0),
+    "south_pole": (-89.0, 0.0),
 }
 
 # Production-baseline parameters reused across cells (mirror the
@@ -95,12 +94,15 @@ PADDING = 10
 
 def _great_circle_distance(lat1, lon1, lat2, lon2):
     """Great-circle distance (radians) between two (lat, lon) points in degrees."""
-    a1 = np.deg2rad(lat1); o1 = np.deg2rad(lon1)
-    a2 = np.deg2rad(lat2); o2 = np.deg2rad(lon2)
+    a1 = np.deg2rad(lat1)
+    o1 = np.deg2rad(lon1)
+    a2 = np.deg2rad(lat2)
+    o2 = np.deg2rad(lon2)
     return np.arccos(
         np.clip(
             np.sin(a1) * np.sin(a2) + np.cos(a1) * np.cos(a2) * np.cos(o2 - o1),
-            -1.0, 1.0,
+            -1.0,
+            1.0,
         )
     )
 
@@ -164,8 +166,10 @@ def _run_region(name, grid, etopo_dir: str, etopo_cg: int):
     print(f"\n========================================")
     print(f"region: {name}")
     print(f"  target  (lat, lon) = ({lat_deg:.2f}°, {lon_deg:.2f}°)")
-    print(f"  nearest cell idx   = {cell_idx}  centroid = "
-          f"({clat_deg:.2f}°, {clon_deg:.2f}°)")
+    print(
+        f"  nearest cell idx   = {cell_idx}  centroid = "
+        f"({clat_deg:.2f}°, {clon_deg:.2f}°)"
+    )
     try:
         cell, _clat, _clon, remask_for_sa = _build_cell_from_etopo(
             grid, cell_idx, etopo_dir, etopo_cg
@@ -179,9 +183,15 @@ def _run_region(name, grid, etopo_dir: str, etopo_cg: int):
 
     # Prior comparison (3-way) at the production baseline.
     result = _diagnose(
-        name, cell,
-        nhi=NHI, nhj=NHJ, U=U, V=V,
-        lmbda_fa=LMBDA_FA, lmbda_sa=LMBDA_SA, n_modes=N_MODES,
+        name,
+        cell,
+        nhi=NHI,
+        nhj=NHJ,
+        U=U,
+        V=V,
+        lmbda_fa=LMBDA_FA,
+        lmbda_sa=LMBDA_SA,
+        n_modes=N_MODES,
         truth_freqs=None,  # no ground truth for real-data cells
         remask_for_sa=remask_for_sa,
     )
@@ -190,17 +200,31 @@ def _run_region(name, grid, etopo_dir: str, etopo_cg: int):
     # winner per cell). Side-by-side both lets the reader see whether
     # selector preference flips with the regularization regime.
     _selector_compare(
-        name, cell,
-        nhi=NHI, nhj=NHJ, U=U, V=V,
-        lmbda_fa=LMBDA_FA, lmbda_sa=LMBDA_SA, n_modes=N_MODES,
-        prior_for_compare=None, truth_freqs=None,
+        name,
+        cell,
+        nhi=NHI,
+        nhj=NHJ,
+        U=U,
+        V=V,
+        lmbda_fa=LMBDA_FA,
+        lmbda_sa=LMBDA_SA,
+        n_modes=N_MODES,
+        prior_for_compare=None,
+        truth_freqs=None,
         remask_for_sa=remask_for_sa,
     )
     _selector_compare(
-        f"{name}_gcv", cell,
-        nhi=NHI, nhj=NHJ, U=U, V=V,
-        lmbda_fa=result["lambda"], lmbda_sa=result["lambda"], n_modes=N_MODES,
-        prior_for_compare=IsotropicPrior(), truth_freqs=None,
+        f"{name}_gcv",
+        cell,
+        nhi=NHI,
+        nhj=NHJ,
+        U=U,
+        V=V,
+        lmbda_fa=result["lambda"],
+        lmbda_sa=result["lambda"],
+        n_modes=N_MODES,
+        prior_for_compare=IsotropicPrior(),
+        truth_freqs=None,
         remask_for_sa=remask_for_sa,
     )
 
@@ -217,22 +241,22 @@ def _parse_args(argv):
         type=str,
         default=None,
         help="Path to an ICON grid .nc file (e.g. R2B4). If omitted, falls back "
-             "to the bundled etopo_single_cell fixture grid (single polar cell only).",
+        "to the bundled etopo_single_cell fixture grid (single polar cell only).",
     )
     p.add_argument(
         "--etopo-dir",
         type=str,
         default=None,
         help="Directory of ETOPO 15s NetCDF tiles. If omitted, uses the bundled "
-             "single-cell fixture tiles.",
+        "single-cell fixture tiles.",
     )
     p.add_argument(
         "--etopo-cg",
         type=int,
         default=4,
         help="ETOPO coarse-graining factor (default 4 = production). The "
-             "bundled fixture is pre-downsampled by 20× so the demo path "
-             "auto-sets this to 1.",
+        "bundled fixture is pre-downsampled by 20× so the demo path "
+        "auto-sets this to 1.",
     )
     p.add_argument(
         "--regions",
@@ -249,9 +273,18 @@ def main(argv=None):
     repo_root = Path(__file__).resolve().parents[1]
 
     if args.icon_grid is None or args.etopo_dir is None:
-        print("No --icon-grid / --etopo-dir provided — falling back to bundled "
-              "etopo_single_cell fixture (single polar cell only).")
-        fixture_dir = repo_root / "tests" / "reproducibility" / "fixtures" / "etopo_single_cell" / "input"
+        print(
+            "No --icon-grid / --etopo-dir provided — falling back to bundled "
+            "etopo_single_cell fixture (single polar cell only)."
+        )
+        fixture_dir = (
+            repo_root
+            / "tests"
+            / "reproducibility"
+            / "fixtures"
+            / "etopo_single_cell"
+            / "input"
+        )
         icon_grid_path = str(fixture_dir / "icon_grid.nc")
         etopo_dir = str(fixture_dir / "etopo")
         etopo_cg = 1  # bundle is pre-downsampled
@@ -274,6 +307,7 @@ def main(argv=None):
         except Exception as exc:
             print(f"\nregion {name} failed: {exc}")
             import traceback
+
             traceback.print_exc()
     return 0
 

--- a/scripts/validate_cells_of_interest.py
+++ b/scripts/validate_cells_of_interest.py
@@ -118,6 +118,10 @@ def _build_cell_from_etopo(grid, cell_idx: int, etopo_dir: str, etopo_cg: int = 
 
     Mirrors the load path in
     ``tests/reproducibility/capture/capture_etopo_single_cell._run_pipeline``.
+
+    Returns ``(cell, clat_verts, clon_verts, remask_for_sa)``: cell is
+    the rectangular cover; ``remask_for_sa(c)`` switches to triangle
+    masking for SA, matching production semantics.
     """
     lat_verts_orig = np.degrees(grid.clat_vertices[cell_idx])
     lon_verts_orig = np.degrees(grid.clon_vertices[cell_idx])
@@ -140,7 +144,11 @@ def _build_cell_from_etopo(grid, cell_idx: int, etopo_dir: str, etopo_cg: int = 
 
     cell = var.topo_cell()
     utils.get_lat_lon_segments(clat_verts, clon_verts, cell, topo, rect=True)
-    return cell, clat_verts, clon_verts
+
+    def remask_for_sa(c):
+        utils.get_lat_lon_segments(clat_verts, clon_verts, c, topo, rect=False)
+
+    return cell, clat_verts, clon_verts, remask_for_sa
 
 
 # ----------------------------------------------------------------------
@@ -159,7 +167,9 @@ def _run_region(name, grid, etopo_dir: str, etopo_cg: int):
     print(f"  nearest cell idx   = {cell_idx}  centroid = "
           f"({clat_deg:.2f}°, {clon_deg:.2f}°)")
     try:
-        cell, *_ = _build_cell_from_etopo(grid, cell_idx, etopo_dir, etopo_cg)
+        cell, _clat, _clon, remask_for_sa = _build_cell_from_etopo(
+            grid, cell_idx, etopo_dir, etopo_cg
+        )
     except Exception as exc:
         print(f"  ETOPO load failed: {exc} — SKIPPING")
         return
@@ -173,6 +183,7 @@ def _run_region(name, grid, etopo_dir: str, etopo_cg: int):
         nhi=NHI, nhj=NHJ, U=U, V=V,
         lmbda_fa=LMBDA_FA, lmbda_sa=LMBDA_SA, n_modes=N_MODES,
         truth_freqs=None,  # no ground truth for real-data cells
+        remask_for_sa=remask_for_sa,
     )
     # Selectors under the production regime, then under the
     # isotropic-at-λ_GCV regime (the one that may be the empirical
@@ -183,12 +194,14 @@ def _run_region(name, grid, etopo_dir: str, etopo_cg: int):
         nhi=NHI, nhj=NHJ, U=U, V=V,
         lmbda_fa=LMBDA_FA, lmbda_sa=LMBDA_SA, n_modes=N_MODES,
         prior_for_compare=None, truth_freqs=None,
+        remask_for_sa=remask_for_sa,
     )
     _selector_compare(
         f"{name}_gcv", cell,
         nhi=NHI, nhj=NHJ, U=U, V=V,
         lmbda_fa=result["lambda"], lmbda_sa=result["lambda"], n_modes=N_MODES,
         prior_for_compare=IsotropicPrior(), truth_freqs=None,
+        remask_for_sa=remask_for_sa,
     )
 
 

--- a/scripts/validate_hyperparam_defaults.py
+++ b/scripts/validate_hyperparam_defaults.py
@@ -56,7 +56,6 @@ from pycsa.core.priors import IsotropicPrior
 from pycsa.core.validation import spatial_cv_score
 from pycsa.wrappers import interface
 
-
 OUTPUT_DIR = Path(__file__).resolve().parent / "validate_outputs"
 
 
@@ -196,7 +195,9 @@ def _build_aleutians_cell():
     FA → mode-select → re-mask → SA flow in the capture script.
     """
     repo_root = Path(__file__).resolve().parents[1]
-    fixture_dir = repo_root / "tests" / "reproducibility" / "fixtures" / "regional_merit"
+    fixture_dir = (
+        repo_root / "tests" / "reproducibility" / "fixtures" / "regional_merit"
+    )
     input_dir = fixture_dir / "input"
     bundled_grid = input_dir / "icon_grid.nc"
     bundled_merit_dir = str(input_dir / "merit") + "/"
@@ -251,7 +252,16 @@ def _materialize_design_matrix(nhi: int, nhj: int, cell):
 
 
 def _run_fa_sa(
-    nhi, nhj, U, V, cell, *, lmbda_fa, lmbda_sa, n_modes, prior=None,
+    nhi,
+    nhj,
+    U,
+    V,
+    cell,
+    *,
+    lmbda_fa,
+    lmbda_sa,
+    n_modes,
+    prior=None,
     remask_for_sa=None,
 ):
     """Run FA (rectangular cover) → greedy mode select → re-mask to
@@ -300,7 +310,13 @@ def _run_fa_sa(
 
 
 def _pick_sa_lambda_via_gcv(
-    cell, nhi, nhj, k_idxs, l_idxs, *, remask_for_sa,
+    cell,
+    nhi,
+    nhj,
+    k_idxs,
+    l_idxs,
+    *,
+    remask_for_sa,
 ):
     """Run JointGCV on the *SA* design matrix and return Hyperparams.
 
@@ -330,8 +346,16 @@ def _pick_sa_lambda_via_gcv(
 
 
 def _pick_sa_lambda_via_spatial_cv(
-    cell, nhi, nhj, k_idxs, l_idxs, *,
-    remask_for_sa, n_folds=4, buffer_fraction=0.05, rng_seed=0,
+    cell,
+    nhi,
+    nhj,
+    k_idxs,
+    l_idxs,
+    *,
+    remask_for_sa,
+    n_folds=4,
+    buffer_fraction=0.05,
+    rng_seed=0,
 ):
     """Pick λ via 4-fold spatial CV on the *SA* design matrix.
 
@@ -354,11 +378,11 @@ def _pick_sa_lambda_via_spatial_cv(
     fobj_sa.set_kls(k_idxs, l_idxs, recompute_nhij=False)
     fobj_sa.do_full(side_cell)
     M_sa = np.asarray(lin_reg.get_coeffs(fobj_sa, ctx=fobj_sa.ctx))
-    coords = np.column_stack(
-        [np.asarray(side_cell.lon_m), np.asarray(side_cell.lat_m)]
-    )
+    coords = np.column_stack([np.asarray(side_cell.lon_m), np.asarray(side_cell.lat_m)])
     selector = SpatialCVSelector(
-        coords=coords, n_folds=n_folds, buffer_fraction=buffer_fraction,
+        coords=coords,
+        n_folds=n_folds,
+        buffer_fraction=buffer_fraction,
         rng_seed=rng_seed,
     )
     hp = build_spectral_prior(
@@ -372,8 +396,17 @@ def _pick_sa_lambda_via_spatial_cv(
 
 
 def _holdout_sa_mse(
-    cell, nhi, nhj, k_idxs, l_idxs, *, prior, lmbda_sa,
-    n_folds=4, buffer_fraction=0.05, remask_for_sa=None,
+    cell,
+    nhi,
+    nhj,
+    k_idxs,
+    l_idxs,
+    *,
+    prior,
+    lmbda_sa,
+    n_folds=4,
+    buffer_fraction=0.05,
+    remask_for_sa=None,
 ):
     """4-fold spatial holdout MSE for an SA fit on a specified mode set.
 
@@ -393,14 +426,20 @@ def _holdout_sa_mse(
     fobj_sa.set_kls(k_idxs, l_idxs, recompute_nhij=False)
     fobj_sa.do_full(side_cell)
     M_sa = np.asarray(lin_reg.get_coeffs(fobj_sa, ctx=fobj_sa.ctx))
-    coords = np.column_stack([
-        np.asarray(side_cell.lon_m), np.asarray(side_cell.lat_m),
-    ])
+    coords = np.column_stack(
+        [
+            np.asarray(side_cell.lon_m),
+            np.asarray(side_cell.lat_m),
+        ]
+    )
     result = spatial_cv_score(
         prior=prior if prior is not None else IsotropicPrior(),
         lmbda=max(float(lmbda_sa), 1e-12),
-        design_matrix=M_sa, data=np.asarray(side_cell.topo_m),
-        coords=coords, n_folds=n_folds, buffer_fraction=buffer_fraction,
+        design_matrix=M_sa,
+        data=np.asarray(side_cell.topo_m),
+        coords=coords,
+        n_folds=n_folds,
+        buffer_fraction=buffer_fraction,
         rng_seed=0,
     )
     return result["mean_heldout_mse"], M_sa.shape[1]
@@ -441,7 +480,17 @@ def _build_idealised_freqs_ref(nhi: int = 12, nhj: int = 12, seed: int = 777):
 
 
 def _run_fa_then_selector(
-    nhi, nhj, U, V, cell, *, lmbda_fa, lmbda_sa, n_modes, prior, selector,
+    nhi,
+    nhj,
+    U,
+    V,
+    cell,
+    *,
+    lmbda_fa,
+    lmbda_sa,
+    n_modes,
+    prior,
+    selector,
     remask_for_sa=None,
 ):
     """Run FA (rectangular cover) → selector → re-mask → SA.
@@ -481,6 +530,7 @@ def _run_fa_then_selector(
         # Fall back to greedy padding if selector picked too few unique
         # modes (rare; defensive only).
         from pycsa.core.mode_selection import GreedyArgmax
+
         gk, gl = GreedyArgmax()(fq, n_modes=n_modes)
         for k, l in zip(gk, gl):
             if (k, l) not in set(zip(k_idxs, l_idxs)):
@@ -504,8 +554,19 @@ def _run_fa_then_selector(
 
 
 def _selector_compare(
-    name, cell, nhi, nhj, U, V, lmbda_fa, lmbda_sa, n_modes,
-    *, prior_for_compare, truth_freqs, remask_for_sa=None,
+    name,
+    cell,
+    nhi,
+    nhj,
+    U,
+    V,
+    lmbda_fa,
+    lmbda_sa,
+    n_modes,
+    *,
+    prior_for_compare,
+    truth_freqs,
+    remask_for_sa=None,
 ):
     """Compare Greedy / OMP / Lasso on the same (prior, lmbda) setting.
 
@@ -515,11 +576,12 @@ def _selector_compare(
     setting.
     """
     prior_label = (
-        type(prior_for_compare).__name__ if prior_for_compare is not None
-        else "None"
+        type(prior_for_compare).__name__ if prior_for_compare is not None else "None"
     )
-    print(f"\n--- {name} : selector comparison "
-          f"(prior={prior_label}, λ_fa={lmbda_fa:.2e}, λ_sa={lmbda_sa:.2e}) ---")
+    print(
+        f"\n--- {name} : selector comparison "
+        f"(prior={prior_label}, λ_fa={lmbda_fa:.2e}, λ_sa={lmbda_sa:.2e}) ---"
+    )
 
     selectors = {
         "Greedy": GreedyArgmax(),
@@ -529,14 +591,24 @@ def _selector_compare(
     outputs = {}
     for tag, sel in selectors.items():
         uw, freqs_sa, dat, (kis, lis) = _run_fa_then_selector(
-            nhi, nhj, U, V, cell,
-            lmbda_fa=lmbda_fa, lmbda_sa=lmbda_sa, n_modes=n_modes,
-            prior=prior_for_compare, selector=sel,
+            nhi,
+            nhj,
+            U,
+            V,
+            cell,
+            lmbda_fa=lmbda_fa,
+            lmbda_sa=lmbda_sa,
+            n_modes=n_modes,
+            prior=prior_for_compare,
+            selector=sel,
             remask_for_sa=remask_for_sa,
         )
         outputs[tag] = {
-            "uw": uw, "freqs_sa": freqs_sa, "dat": dat,
-            "k_idxs": kis, "l_idxs": lis,
+            "uw": uw,
+            "freqs_sa": freqs_sa,
+            "dat": dat,
+            "k_idxs": kis,
+            "l_idxs": lis,
         }
 
     # Pairwise Jaccard of the selected mode sets (greedy as reference).
@@ -544,8 +616,10 @@ def _selector_compare(
     for tag in ("OMP(b=5)", "Lasso"):
         s = set(zip(outputs[tag]["k_idxs"], outputs[tag]["l_idxs"]))
         jaccard = len(ref_set & s) / max(len(ref_set | s), 1)
-        print(f"  Jaccard({tag} vs Greedy) = {jaccard:.3f}  "
-              f"(mode-set distance, NOT quality)")
+        print(
+            f"  Jaccard({tag} vs Greedy) = {jaccard:.3f}  "
+            f"(mode-set distance, NOT quality)"
+        )
 
     # Quality metric. For idealised: truth distance on freqs_sa (which
     # IS selector-dependent). For real-data: SA-stage holdout MSE on the
@@ -559,19 +633,25 @@ def _selector_compare(
     else:
         for tag, out in outputs.items():
             mse, n_sa = _holdout_sa_mse(
-                cell, nhi, nhj, out["k_idxs"], out["l_idxs"],
-                prior=prior_for_compare, lmbda_sa=lmbda_sa,
+                cell,
+                nhi,
+                nhj,
+                out["k_idxs"],
+                out["l_idxs"],
+                prior=prior_for_compare,
+                lmbda_sa=lmbda_sa,
                 remask_for_sa=remask_for_sa,
             )
-            print(f"    4-fold holdout SA-MSE  {tag:<10} = {mse:.4e}  "
-                  f"(SA basis size = {n_sa})")
+            print(
+                f"    4-fold holdout SA-MSE  {tag:<10} = {mse:.4e}  "
+                f"(SA basis size = {n_sa})"
+            )
 
     # Side-by-side plot: input + 3 SA reconstructions.
     plot_path = _plot_panels(
         f"{name}_selectors",
-        arrays=[np.nan_to_num(cell.topo)] + [
-            np.nan_to_num(outputs[tag]["dat"]) for tag in selectors
-        ],
+        arrays=[np.nan_to_num(cell.topo)]
+        + [np.nan_to_num(outputs[tag]["dat"]) for tag in selectors],
         titles=["input"] + [f"SA: {tag}" for tag in selectors],
         out_dir=OUTPUT_DIR,
     )
@@ -604,8 +684,18 @@ def _plot_panels(name, arrays, titles, out_dir):
 
 
 def _diagnose(
-    name, cell, nhi, nhj, U, V, lmbda_fa, lmbda_sa, n_modes,
-    *, truth_freqs=None, remask_for_sa=None,
+    name,
+    cell,
+    nhi,
+    nhj,
+    U,
+    V,
+    lmbda_fa,
+    lmbda_sa,
+    n_modes,
+    *,
+    truth_freqs=None,
+    remask_for_sa=None,
 ):
     """Run baseline vs hyperparam-selected pipeline and report metrics.
 
@@ -648,11 +738,7 @@ def _diagnose(
         f"  joint GCV:  alpha = {hp_joint.alpha:.3f}  "
         f"lambda = {hp_joint.lmbda:.3e}  ← JointGCVSelector"
     )
-    print(
-        "  baseline lmbda_fa = {:.3e}  lmbda_sa = {:.3e}".format(
-            lmbda_fa, lmbda_sa
-        )
-    )
+    print("  baseline lmbda_fa = {:.3e}  lmbda_sa = {:.3e}".format(lmbda_fa, lmbda_sa))
 
     # Three pipelines, identical mode-selection + SA paths, only the
     # FA/SA prior+lmbda combination differs:
@@ -663,18 +749,39 @@ def _diagnose(
     # the per-mode structure from the contribution of just picking a
     # different scalar lambda.
     uw_base, freqs_sa_base, dat_base, k_base, l_base = _run_fa_sa(
-        nhi, nhj, U, V, cell,
-        lmbda_fa=lmbda_fa, lmbda_sa=lmbda_sa, n_modes=n_modes, prior=None,
+        nhi,
+        nhj,
+        U,
+        V,
+        cell,
+        lmbda_fa=lmbda_fa,
+        lmbda_sa=lmbda_sa,
+        n_modes=n_modes,
+        prior=None,
         remask_for_sa=remask_for_sa,
     )
     uw_iso, freqs_sa_iso, dat_iso, k_iso, l_iso = _run_fa_sa(
-        nhi, nhj, U, V, cell,
-        lmbda_fa=hp.lmbda, lmbda_sa=hp.lmbda, n_modes=n_modes,
-        prior=IsotropicPrior(), remask_for_sa=remask_for_sa,
+        nhi,
+        nhj,
+        U,
+        V,
+        cell,
+        lmbda_fa=hp.lmbda,
+        lmbda_sa=hp.lmbda,
+        n_modes=n_modes,
+        prior=IsotropicPrior(),
+        remask_for_sa=remask_for_sa,
     )
     uw_sel, freqs_sa_sel, dat_sel, k_sel, l_sel = _run_fa_sa(
-        nhi, nhj, U, V, cell,
-        lmbda_fa=hp.lmbda, lmbda_sa=hp.lmbda, n_modes=n_modes, prior=hp.prior,
+        nhi,
+        nhj,
+        U,
+        V,
+        cell,
+        lmbda_fa=hp.lmbda,
+        lmbda_sa=hp.lmbda,
+        n_modes=n_modes,
+        prior=hp.prior,
         remask_for_sa=remask_for_sa,
     )
     # Joint-GCV pipeline: uses hp_joint.prior + hp_joint.lmbda. When
@@ -682,9 +789,16 @@ def _diagnose(
     # picks alpha>0 this is a non-trivial structured prior at a
     # jointly-optimized scale.
     uw_jnt, freqs_sa_jnt, dat_jnt, k_jnt, l_jnt = _run_fa_sa(
-        nhi, nhj, U, V, cell,
-        lmbda_fa=hp_joint.lmbda, lmbda_sa=hp_joint.lmbda, n_modes=n_modes,
-        prior=hp_joint.prior, remask_for_sa=remask_for_sa,
+        nhi,
+        nhj,
+        U,
+        V,
+        cell,
+        lmbda_fa=hp_joint.lmbda,
+        lmbda_sa=hp_joint.lmbda,
+        n_modes=n_modes,
+        prior=hp_joint.prior,
+        remask_for_sa=remask_for_sa,
     )
 
     # ---- Difference summary vs baseline ----
@@ -717,10 +831,11 @@ def _diagnose(
         print(f"      baseline                  = {d_base:.4e}")
         print(f"      isotropic-at-selected-λ   = {d_iso:.4e}")
         print(f"      selected (SpectralPrior)  = {d_sel:.4e}")
-        print(f"      joint GCV (α={hp_joint.alpha:.2f}, λ={hp_joint.lmbda:.2e})"
-              f" = {d_jnt:.4e}")
-        for tag, d in (("isotropic", d_iso), ("selected", d_sel),
-                       ("joint_GCV", d_jnt)):
+        print(
+            f"      joint GCV (α={hp_joint.alpha:.2f}, λ={hp_joint.lmbda:.2e})"
+            f" = {d_jnt:.4e}"
+        )
+        for tag, d in (("isotropic", d_iso), ("selected", d_sel), ("joint_GCV", d_jnt)):
             if d_base > 0:
                 rel = (d_base - d) / d_base * 100.0
                 verdict = "better" if d < d_base else "worse" if d > d_base else "tie"
@@ -740,38 +855,75 @@ def _diagnose(
         # FA-stage holdout was an artifact — lmbda_fa=0 is by design,
         # so FA isn't tasked with generalizing to held-out points.
         mse_base, n_sa_base = _holdout_sa_mse(
-            cell, nhi, nhj, k_base, l_base,
-            prior=None, lmbda_sa=lmbda_sa, remask_for_sa=remask_for_sa,
+            cell,
+            nhi,
+            nhj,
+            k_base,
+            l_base,
+            prior=None,
+            lmbda_sa=lmbda_sa,
+            remask_for_sa=remask_for_sa,
         )
         mse_iso, n_sa_iso = _holdout_sa_mse(
-            cell, nhi, nhj, k_iso, l_iso,
-            prior=IsotropicPrior(), lmbda_sa=hp.lmbda,
+            cell,
+            nhi,
+            nhj,
+            k_iso,
+            l_iso,
+            prior=IsotropicPrior(),
+            lmbda_sa=hp.lmbda,
             remask_for_sa=remask_for_sa,
         )
         mse_sel, n_sa_sel = _holdout_sa_mse(
-            cell, nhi, nhj, k_sel, l_sel,
-            prior=hp.prior, lmbda_sa=hp.lmbda, remask_for_sa=remask_for_sa,
-        )
-        mse_jnt, n_sa_jnt = _holdout_sa_mse(
-            cell, nhi, nhj, k_jnt, l_jnt,
-            prior=hp_joint.prior, lmbda_sa=hp_joint.lmbda,
+            cell,
+            nhi,
+            nhj,
+            k_sel,
+            l_sel,
+            prior=hp.prior,
+            lmbda_sa=hp.lmbda,
             remask_for_sa=remask_for_sa,
         )
-        print(f"    4-fold spatial holdout SA-MSE (correct metric — "
-              f"SA basis built from each pipeline's own picked modes)")
-        print(f"      baseline (λ_fa={lmbda_fa:.2e}, λ_sa={lmbda_sa:.2e}, no prior) "
-              f"= {mse_base:.4e}  (SA basis size = {n_sa_base})")
-        print(f"      isotropic-at-selected-λ              = {mse_iso:.4e}  "
-              f"(SA basis size = {n_sa_iso})")
-        print(f"      selected (SpectralPrior at GCV λ)    = {mse_sel:.4e}  "
-              f"(SA basis size = {n_sa_sel})")
-        print(f"      joint GCV (α={hp_joint.alpha:.2f}, λ={hp_joint.lmbda:.2e})"
-              f" = {mse_jnt:.4e}  (SA basis size = {n_sa_jnt})")
-        for tag, m in (("isotropic", mse_iso), ("selected", mse_sel),
-                       ("joint_GCV", mse_jnt)):
+        mse_jnt, n_sa_jnt = _holdout_sa_mse(
+            cell,
+            nhi,
+            nhj,
+            k_jnt,
+            l_jnt,
+            prior=hp_joint.prior,
+            lmbda_sa=hp_joint.lmbda,
+            remask_for_sa=remask_for_sa,
+        )
+        print(
+            f"    4-fold spatial holdout SA-MSE (correct metric — "
+            f"SA basis built from each pipeline's own picked modes)"
+        )
+        print(
+            f"      baseline (λ_fa={lmbda_fa:.2e}, λ_sa={lmbda_sa:.2e}, no prior) "
+            f"= {mse_base:.4e}  (SA basis size = {n_sa_base})"
+        )
+        print(
+            f"      isotropic-at-selected-λ              = {mse_iso:.4e}  "
+            f"(SA basis size = {n_sa_iso})"
+        )
+        print(
+            f"      selected (SpectralPrior at GCV λ)    = {mse_sel:.4e}  "
+            f"(SA basis size = {n_sa_sel})"
+        )
+        print(
+            f"      joint GCV (α={hp_joint.alpha:.2f}, λ={hp_joint.lmbda:.2e})"
+            f" = {mse_jnt:.4e}  (SA basis size = {n_sa_jnt})"
+        )
+        for tag, m in (
+            ("isotropic", mse_iso),
+            ("selected", mse_sel),
+            ("joint_GCV", mse_jnt),
+        ):
             if mse_base > 0:
                 rel = (mse_base - m) / mse_base * 100.0
-                verdict = "better" if m < mse_base else "worse" if m > mse_base else "tie"
+                verdict = (
+                    "better" if m < mse_base else "worse" if m > mse_base else "tie"
+                )
                 print(f"      {tag:<10} vs baseline = {rel:+.2f}%  ({verdict})")
         # Structure-vs-scale isolation
         if mse_iso > 0:
@@ -792,8 +944,11 @@ def _diagnose(
             np.nan_to_num(dat_sel),
         ],
         titles=[
-            "input (idealised: planted topo)" if truth_freqs is not None
-            else "input topography",
+            (
+                "input (idealised: planted topo)"
+                if truth_freqs is not None
+                else "input topography"
+            ),
             f"baseline (λ_fa={lmbda_fa:.0e})",
             f"isotropic at GCV λ={hp.lmbda:.2e}",
             f"selected: SpectralPrior(α={hp.alpha:.2f})",
@@ -818,29 +973,47 @@ def main(argv=None):
     )
 
     # ---- Idealised: numbers from runs/idealised_isosceles.py ----
-    cell_id, _triangle, remask_id = _build_idealised_cell(
-        nhi=12, nhj=12, seed=777
-    )
+    cell_id, _triangle, remask_id = _build_idealised_cell(nhi=12, nhj=12, seed=777)
     truth_freqs = _build_idealised_freqs_ref(nhi=12, nhj=12, seed=777)
     result = _diagnose(
         "idealised",
         cell_id,
-        nhi=12, nhj=12, U=1.0, V=1.0,
-        lmbda_fa=1.0e-1, lmbda_sa=1.0e-6, n_modes=14,
-        truth_freqs=truth_freqs, remask_for_sa=remask_id,
-    )
-    _selector_compare(
-        "idealised", cell_id,
-        nhi=12, nhj=12, U=1.0, V=1.0,
-        lmbda_fa=1.0e-1, lmbda_sa=1.0e-6, n_modes=14,
-        prior_for_compare=None, truth_freqs=truth_freqs,
+        nhi=12,
+        nhj=12,
+        U=1.0,
+        V=1.0,
+        lmbda_fa=1.0e-1,
+        lmbda_sa=1.0e-6,
+        n_modes=14,
+        truth_freqs=truth_freqs,
         remask_for_sa=remask_id,
     )
     _selector_compare(
-        "idealised_gcv", cell_id,
-        nhi=12, nhj=12, U=1.0, V=1.0,
-        lmbda_fa=result["lambda"], lmbda_sa=result["lambda"], n_modes=14,
-        prior_for_compare=IsotropicPrior(), truth_freqs=truth_freqs,
+        "idealised",
+        cell_id,
+        nhi=12,
+        nhj=12,
+        U=1.0,
+        V=1.0,
+        lmbda_fa=1.0e-1,
+        lmbda_sa=1.0e-6,
+        n_modes=14,
+        prior_for_compare=None,
+        truth_freqs=truth_freqs,
+        remask_for_sa=remask_id,
+    )
+    _selector_compare(
+        "idealised_gcv",
+        cell_id,
+        nhi=12,
+        nhj=12,
+        U=1.0,
+        V=1.0,
+        lmbda_fa=result["lambda"],
+        lmbda_sa=result["lambda"],
+        n_modes=14,
+        prior_for_compare=IsotropicPrior(),
+        truth_freqs=truth_freqs,
         remask_for_sa=remask_id,
     )
 
@@ -853,22 +1026,42 @@ def main(argv=None):
     result = _diagnose(
         "aleutians_merit",
         cell_al,
-        nhi=24, nhj=48, U=10.0, V=0.0,
-        lmbda_fa=0.0, lmbda_sa=1.0e-1, n_modes=50,
-        truth_freqs=None, remask_for_sa=remask_al,
-    )
-    _selector_compare(
-        "aleutians_merit", cell_al,
-        nhi=24, nhj=48, U=10.0, V=0.0,
-        lmbda_fa=0.0, lmbda_sa=1.0e-1, n_modes=50,
-        prior_for_compare=None, truth_freqs=None,
+        nhi=24,
+        nhj=48,
+        U=10.0,
+        V=0.0,
+        lmbda_fa=0.0,
+        lmbda_sa=1.0e-1,
+        n_modes=50,
+        truth_freqs=None,
         remask_for_sa=remask_al,
     )
     _selector_compare(
-        "aleutians_merit_gcv", cell_al,
-        nhi=24, nhj=48, U=10.0, V=0.0,
-        lmbda_fa=result["lambda"], lmbda_sa=result["lambda"], n_modes=50,
-        prior_for_compare=IsotropicPrior(), truth_freqs=None,
+        "aleutians_merit",
+        cell_al,
+        nhi=24,
+        nhj=48,
+        U=10.0,
+        V=0.0,
+        lmbda_fa=0.0,
+        lmbda_sa=1.0e-1,
+        n_modes=50,
+        prior_for_compare=None,
+        truth_freqs=None,
+        remask_for_sa=remask_al,
+    )
+    _selector_compare(
+        "aleutians_merit_gcv",
+        cell_al,
+        nhi=24,
+        nhj=48,
+        U=10.0,
+        V=0.0,
+        lmbda_fa=result["lambda"],
+        lmbda_sa=result["lambda"],
+        n_modes=50,
+        prior_for_compare=IsotropicPrior(),
+        truth_freqs=None,
         remask_for_sa=remask_al,
     )
     return 0

--- a/scripts/validate_hyperparam_defaults.py
+++ b/scripts/validate_hyperparam_defaults.py
@@ -1,0 +1,769 @@
+"""One-script empirical check for the structured-prior hyperparameter defaults.
+
+Runs :func:`pycsa.core.hyperparams.build_spectral_prior` on the two
+fixtures the kernel-spike plan singled out (idealised + Aleutians MERIT,
+the third fixture — polar ETOPO — is skipped here for speed; run by
+hand if you want it) and reports three things per fixture:
+
+1. the alpha chosen by :class:`EmpiricalSpectralSlope` (with stderr,
+   R² — so you can spot a poorly-fit periodogram before trusting it);
+2. the lambda chosen by :class:`GCVSelector`;
+3. a *quality* comparison vs. the existing production pipeline (no
+   prior, fixture lmbda):
+
+   - ``‖Δuw_pmf‖∞ / ‖uw_pmf_baseline‖∞`` — *difference* from baseline.
+   - **Improvement metric** — for idealised the script knows the
+     planted-modes ground truth (``freqs_ref`` from the deterministic
+     22-mode superposition) and reports
+     ``‖freqs_sa − freqs_ref‖_F`` for both pipelines; for Aleutians
+     there is no ground truth so we report 4-fold spatial-holdout
+     reconstruction MSE via :func:`pycsa.core.validation.spatial_cv_score`.
+
+A 3-panel side-by-side topography plot lands under
+``scripts/validate_outputs/`` for each fixture: truth (or input) |
+baseline reconstruction | selected reconstruction.
+
+**Not a benchmark.** This script gives one comparison per fixture, at
+one choice of (alpha_selector, lambda_selector). It does *not* prove
+GCV is the right default in general; it confirms the defaults are
+wired correctly and produces concrete numbers that the JORS
+subsection can cite.
+
+Run::
+
+    ~/anaconda3/envs/playground/bin/python scripts/validate_hyperparam_defaults.py
+
+Requires playground env (Python 3.12). For Aleutians, the bundled MERIT
+fixture under tests/reproducibility/fixtures/regional_merit/input/ must
+exist (it ships in the repo).
+"""
+
+from __future__ import annotations
+
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+# netCDF4 must be imported before pycsa.core.io per the playground env quirk.
+import netCDF4  # noqa: F401
+import numpy as np
+
+from pycsa.core import fourier, lin_reg, physics, utils, var
+from pycsa.core import io as pcio
+from pycsa.core.hyperparams import JointGCVSelector, build_spectral_prior
+from pycsa.core.mode_selection import GreedyArgmax, LassoSelector, OMPSelector
+from pycsa.core.priors import IsotropicPrior
+from pycsa.core.validation import spatial_cv_score
+from pycsa.wrappers import interface
+
+
+OUTPUT_DIR = Path(__file__).resolve().parent / "validate_outputs"
+
+
+def _column_to_kl_for_fobj(fobj):
+    """Build a column_to_kl callable matching ``f_trans.do_full``'s slicing.
+
+    The FA design matrix M = ``hstack([Ncos, Nsin])`` is produced by
+    ``f_trans.do_full`` which:
+
+    1. builds ``tt_sum`` of shape ``(n_points, nhar_i, nhar_j)``,
+    2. flattens to ``(n_points, nhar_i*nhar_j)`` in C order,
+    3. computes ``bcos``, ``bsin`` elementwise on the flat array,
+    4. slices the flat axis at ``nhar_j/2 - 1`` (cos) and ``nhar_j/2``
+       (sin) — see [fourier.py:215-231].
+
+    So a column index ``c`` in ``M`` maps to a flat ``(mi, mj)`` pair
+    via different offsets in the cos-half and sin-half. This helper
+    inverts that mapping. The returned tuple is ``(k, l) = (mi, mj)``
+    — the same convention ``fobj.set_kls`` expects.
+
+    Even/odd ``nhar_j`` use the same offsets per the slicing branches
+    (the odd branch happens to match the even branch byte-for-byte
+    at the relevant lines).
+    """
+    nhar_i = int(fobj.nhar_i)
+    nhar_j = int(fobj.nhar_j)
+    cos_off = nhar_j // 2 - 1
+    sin_off = nhar_j // 2
+    n_cos = nhar_i * nhar_j - cos_off
+
+    def column_to_kl(c: int):
+        if c < n_cos:
+            flat = c + cos_off
+        else:
+            flat = (c - n_cos) + sin_off
+        return (flat // nhar_j, flat % nhar_j)
+
+    return column_to_kl, n_cos
+
+
+def _dedupe_kl(k_idxs, l_idxs, target_n):
+    """Drop duplicate (k, l) pairs (cos and sin columns for the same
+    mode collide) while preserving selection order. Pads with the
+    next available greedy picks if dedup leaves fewer than target_n
+    — but only as a safety net; for well-behaved selectors the
+    dedupe rate should be small.
+    """
+    seen = set()
+    out_k, out_l = [], []
+    for k, l in zip(k_idxs, l_idxs):
+        key = (int(k), int(l))
+        if key in seen:
+            continue
+        seen.add(key)
+        out_k.append(int(k))
+        out_l.append(int(l))
+        if len(out_k) == target_n:
+            break
+    return out_k, out_l
+
+
+# ----------------------------------------------------------------------
+# Idealised case (deterministic synthetic terrain, no external data)
+# ----------------------------------------------------------------------
+
+
+def _build_idealised_cell(nhi: int = 12, nhj: int = 12, seed: int = 777):
+    """Replicate runs.idealised_isosceles._build_cell + _generate_terrain.
+
+    Lifted inline so the script does not depend on importing internals
+    of ``runs/idealised_isosceles.py`` (which mutates global numpy seed
+    state). Equivalent topography, equivalent cell layout.
+    """
+    np.random.seed(seed)
+    sz = 25
+    nk = np.random.randint(0, 12, size=sz)
+    nl = np.random.randint(-5, 7, size=sz)
+    for ii in range(sz):
+        if nk[ii] == 0 and nl[ii] < 0:
+            nk[ii] += np.random.randint(1, 11)
+    pts = np.array(list(set(zip(nk, nl))))
+    nk = pts[:, 0]
+    nl = pts[:, 1]
+    sz = len(pts)
+    Ak = np.random.random(size=sz) * 100.0
+    sck = np.random.randint(0, 2, size=sz)
+
+    grid = var.grid()
+    cell = var.topo_cell()
+    vid = utils.isosceles(grid, cell)
+    lat_v = grid.clat_vertices[vid, :]
+    lon_v = grid.clon_vertices[vid, :]
+    cell.gen_mgrids()
+    cell.topo = np.zeros_like(cell.lat_grid)
+    for ii in range(sz):
+        nk_scaled = 2.0 * np.pi * nk[ii] / cell.lon.max()
+        nl_scaled = 2.0 * np.pi * nl[ii] / cell.lat.max()
+        bf_amp = Ak[ii]
+        if sck[ii] == 0:
+            cell.topo += bf_amp * np.cos(
+                nk_scaled * cell.lon_grid + nl_scaled * cell.lat_grid
+            )
+        else:
+            cell.topo += bf_amp * np.sin(
+                nk_scaled * cell.lon_grid + nl_scaled * cell.lat_grid
+            )
+    triangle = utils.gen_triangle(lon_v, lat_v)
+    cell.get_masked(triangle=triangle)
+    cell.wlat = float(np.diff(cell.lat).mean())
+    cell.wlon = float(np.diff(cell.lon).mean())
+    return cell, triangle
+
+
+# ----------------------------------------------------------------------
+# Aleutians MERIT case (bundled fixture inputs)
+# ----------------------------------------------------------------------
+
+
+def _build_aleutians_cell():
+    """Reproduce ``tests/reproducibility/capture/capture_regional_merit._run_pipeline``
+    up to the point where the rectangular-cover cell is ready.
+
+    Lifted rather than imported because the capture script's
+    ``_run_pipeline`` returns post-pipeline arrays; we want the cell
+    itself so we can build the design matrix for hyperparam selection.
+    """
+    repo_root = Path(__file__).resolve().parents[1]
+    fixture_dir = repo_root / "tests" / "reproducibility" / "fixtures" / "regional_merit"
+    input_dir = fixture_dir / "input"
+    bundled_grid = input_dir / "icon_grid.nc"
+    bundled_merit_dir = str(input_dir / "merit") + "/"
+
+    grid = var.grid()
+    pcio.ncdata().read_dat(str(bundled_grid), grid)
+
+    lat_verts_orig = np.degrees(grid.clat_vertices[0])
+    lon_verts_orig = np.degrees(grid.clon_vertices[0])
+    clat_verts, clon_verts = utils.handle_latlon_expansion(
+        lat_verts_orig.copy(), lon_verts_orig.copy()
+    )
+
+    params = var.params()
+    params.path_merit = bundled_merit_dir
+    params.lat_extent = clat_verts
+    params.lon_extent = clon_verts
+    params.merit_cg = 1
+    params.padding = 10
+
+    topo = var.topo_cell()
+    reader = pcio.ncdata(padding=params.padding, padding_tol=(60 - params.padding))
+    reader.read_merit_topo(topo, params)
+    topo.topo[np.where(topo.topo < -500.0)] = -500.0
+    topo.gen_mgrids()
+
+    cell = var.topo_cell()
+    utils.get_lat_lon_segments(clat_verts, clon_verts, cell, topo, rect=True)
+    return cell
+
+
+# ----------------------------------------------------------------------
+# Diagnostic core
+# ----------------------------------------------------------------------
+
+
+def _materialize_design_matrix(nhi: int, nhj: int, cell):
+    """Build the FA design matrix ``M`` for hyperparam selection.
+
+    Side-effect free with respect to the cell: we work on a deep copy
+    of the cell so the subsequent ``sappx`` calls see pristine state.
+    """
+    cell_copy = deepcopy(cell)
+    fobj = fourier.f_trans(nhi, nhj)
+    fobj.do_full(cell_copy)
+    M = lin_reg.get_coeffs(fobj, ctx=fobj.ctx)
+    return np.asarray(M)
+
+
+def _run_fa_sa(
+    nhi, nhj, U, V, cell, *, lmbda_fa, lmbda_sa, n_modes, prior=None,
+):
+    """Run FA → greedy mode select → SA.
+
+    Returns ``(uw_sa, freqs_sa, dat_2D_sa, k_idxs, l_idxs)``. The
+    picked mode indices are returned so callers can rebuild the SA
+    design matrix later for SA-stage holdout evaluation. Threads
+    ``prior`` through both FA and SA via the inner ``get_pmf``'s
+    ComputeContext. Default ``prior=None`` reproduces the historical
+    behavior.
+    """
+    work_cell = deepcopy(cell)
+
+    # ---- FA ----
+    first_guess = interface.get_pmf(nhi, nhj, U, V)
+    if prior is not None:
+        first_guess.ctx.prior = prior
+    freqs_fa, _, _ = first_guess.sappx(work_cell, lmbda=lmbda_fa)
+
+    # ---- mode selection (greedy, matching the existing inline loop
+    # used by both capture scripts) ----
+    fq = np.copy(freqs_fa)
+    fq[np.isnan(fq)] = 0.0
+    indices = []
+    for _ in range(n_modes):
+        mx = np.unravel_index(fq.argmax(), fq.shape)
+        indices.append(mx)
+        fq[mx] = 0.0
+    k_idxs = [p[1] for p in indices]
+    l_idxs = [p[0] for p in indices]
+
+    # ---- SA ----
+    second_guess = interface.get_pmf(nhi, nhj, U, V)
+    if prior is not None:
+        second_guess.ctx.prior = prior
+    second_guess.fobj.set_kls(k_idxs, l_idxs, recompute_nhij=False)
+    freqs_sa, uw_sa, dat_2D = second_guess.sappx(
+        work_cell, lmbda=lmbda_sa, updt_analysis=True, scale=1.0
+    )
+    return uw_sa, freqs_sa, np.asarray(dat_2D), k_idxs, l_idxs
+
+
+def _holdout_sa_mse(
+    cell, nhi, nhj, k_idxs, l_idxs, *, prior, lmbda_sa,
+    n_folds=4, buffer_fraction=0.05,
+):
+    """4-fold spatial holdout MSE for an SA fit on a specified mode set.
+
+    Builds the SA design matrix on the cell using the supplied
+    ``(k_idxs, l_idxs)``, then runs :func:`spatial_cv_score` against
+    held-out spatial patches. Uses the supplied ``prior`` + ``lmbda_sa``
+    for the per-fold ridge fit.
+
+    This is the correct out-of-sample metric for the pipeline: SA is
+    where regularization is consumed, and the SA basis is what the
+    downstream physics actually uses. (FA-stage holdout is an
+    artifact because ``lmbda_fa=0`` is by design — FA is a feature
+    extractor for mode selection, not a generalization-target step.)
+    """
+    side_cell = deepcopy(cell)
+    fobj_sa = fourier.f_trans(nhi, nhj)
+    fobj_sa.set_kls(k_idxs, l_idxs, recompute_nhij=False)
+    fobj_sa.do_full(side_cell)
+    M_sa = np.asarray(lin_reg.get_coeffs(fobj_sa, ctx=fobj_sa.ctx))
+    coords = np.column_stack([
+        np.asarray(side_cell.lon_m), np.asarray(side_cell.lat_m),
+    ])
+    result = spatial_cv_score(
+        prior=prior if prior is not None else IsotropicPrior(),
+        lmbda=max(float(lmbda_sa), 1e-12),
+        design_matrix=M_sa, data=np.asarray(side_cell.topo_m),
+        coords=coords, n_folds=n_folds, buffer_fraction=buffer_fraction,
+        rng_seed=0,
+    )
+    return result["mean_heldout_mse"], M_sa.shape[1]
+
+
+# ----------------------------------------------------------------------
+# Quality metrics
+# ----------------------------------------------------------------------
+
+
+def _build_idealised_freqs_ref(nhi: int = 12, nhj: int = 12, seed: int = 777):
+    """Replicate the planted-modes ground-truth spectrum.
+
+    Mirrors ``runs.idealised_isosceles.run`` lines 128-130: place the
+    planted amplitudes ``Ak`` at ``(l+5, k)`` in a ``(nhi, nhj)`` grid.
+    Returned as the same shape the SA pipeline produces so they can be
+    compared via Frobenius norm directly.
+    """
+    np.random.seed(seed)
+    sz = 25
+    nk = np.random.randint(0, 12, size=sz)
+    nl = np.random.randint(-5, 7, size=sz)
+    for ii in range(sz):
+        if nk[ii] == 0 and nl[ii] < 0:
+            nk[ii] += np.random.randint(1, 11)
+    pts = np.array(list(set(zip(nk, nl))))
+    sz = len(pts)
+    Ak = np.random.random(size=sz) * 100.0
+    freqs_ref = np.zeros((nhi, nhj))
+    for cnt, (kk, ll) in enumerate(pts):
+        freqs_ref[ll + 5, kk] = Ak[cnt]
+    return freqs_ref
+
+
+# ----------------------------------------------------------------------
+# Plotting
+# ----------------------------------------------------------------------
+
+
+def _run_fa_then_selector(
+    nhi, nhj, U, V, cell, *, lmbda_fa, lmbda_sa, n_modes, prior, selector,
+):
+    """Run FA, then use ``selector`` (instead of inline argmax) to pick
+    modes, then SA. Returns (uw_sa, freqs_sa, dat_2D_sa).
+
+    Mirrors ``_run_fa_sa`` but calls a pluggable selector. The selector
+    receives the FA spectrum AND the FA design matrix + data — OMP and
+    Lasso need them; GreedyArgmax ignores them.
+    """
+    work_cell = deepcopy(cell)
+
+    # FA stage. We materialize the design matrix in a side cell so
+    # the FA fit itself runs unchanged (do_full + lin_reg.do).
+    side_cell = deepcopy(cell)
+    side_fobj = fourier.f_trans(nhi, nhj)
+    side_fobj.do_full(side_cell)
+    M = np.asarray(lin_reg.get_coeffs(side_fobj, ctx=side_fobj.ctx))
+    column_to_kl, _ = _column_to_kl_for_fobj(side_fobj)
+
+    first_guess = interface.get_pmf(nhi, nhj, U, V)
+    if prior is not None:
+        first_guess.ctx.prior = prior
+    freqs_fa, _, _ = first_guess.sappx(work_cell, lmbda=lmbda_fa)
+
+    # Selector picks (k_idxs, l_idxs).
+    fq = np.copy(freqs_fa)
+    fq[np.isnan(fq)] = 0.0
+    k_picks, l_picks = selector(
+        fq,
+        n_modes=n_modes * 2,  # over-pick to cover cos/sin duplicates
+        design_matrix=M,
+        data=np.asarray(side_cell.topo_m),
+        column_to_kl=column_to_kl,
+    )
+    k_idxs, l_idxs = _dedupe_kl(k_picks, l_picks, target_n=n_modes)
+    if len(k_idxs) < n_modes:
+        # Fall back to greedy padding if selector picked too few unique
+        # modes (rare; defensive only).
+        from pycsa.core.mode_selection import GreedyArgmax
+        gk, gl = GreedyArgmax()(fq, n_modes=n_modes)
+        for k, l in zip(gk, gl):
+            if (k, l) not in set(zip(k_idxs, l_idxs)):
+                k_idxs.append(int(k))
+                l_idxs.append(int(l))
+                if len(k_idxs) == n_modes:
+                    break
+
+    second_guess = interface.get_pmf(nhi, nhj, U, V)
+    if prior is not None:
+        second_guess.ctx.prior = prior
+    second_guess.fobj.set_kls(k_idxs, l_idxs, recompute_nhij=False)
+    freqs_sa, uw_sa, dat_2D = second_guess.sappx(
+        work_cell, lmbda=lmbda_sa, updt_analysis=True, scale=1.0
+    )
+    return uw_sa, freqs_sa, np.asarray(dat_2D), (k_idxs, l_idxs)
+
+
+def _selector_compare(
+    name, cell, nhi, nhj, U, V, lmbda_fa, lmbda_sa, n_modes,
+    *, prior_for_compare, truth_freqs,
+):
+    """Compare Greedy / OMP / Lasso on the same (prior, lmbda) setting.
+
+    ``prior_for_compare`` is the prior used during the FA fit *and* the
+    SA refit. Pass ``None`` to compare selectors at the production
+    baseline; pass ``hp.prior`` to compare them at the GCV-selected
+    setting.
+    """
+    prior_label = (
+        type(prior_for_compare).__name__ if prior_for_compare is not None
+        else "None"
+    )
+    print(f"\n--- {name} : selector comparison "
+          f"(prior={prior_label}, λ_fa={lmbda_fa:.2e}, λ_sa={lmbda_sa:.2e}) ---")
+
+    selectors = {
+        "Greedy": GreedyArgmax(),
+        "OMP(b=5)": OMPSelector(batch_size=5),
+        "Lasso": LassoSelector(),
+    }
+    outputs = {}
+    for tag, sel in selectors.items():
+        uw, freqs_sa, dat, (kis, lis) = _run_fa_then_selector(
+            nhi, nhj, U, V, cell,
+            lmbda_fa=lmbda_fa, lmbda_sa=lmbda_sa, n_modes=n_modes,
+            prior=prior_for_compare, selector=sel,
+        )
+        outputs[tag] = {
+            "uw": uw, "freqs_sa": freqs_sa, "dat": dat,
+            "k_idxs": kis, "l_idxs": lis,
+        }
+
+    # Pairwise Jaccard of the selected mode sets (greedy as reference).
+    ref_set = set(zip(outputs["Greedy"]["k_idxs"], outputs["Greedy"]["l_idxs"]))
+    for tag in ("OMP(b=5)", "Lasso"):
+        s = set(zip(outputs[tag]["k_idxs"], outputs[tag]["l_idxs"]))
+        jaccard = len(ref_set & s) / max(len(ref_set | s), 1)
+        print(f"  Jaccard({tag} vs Greedy) = {jaccard:.3f}  "
+              f"(mode-set distance, NOT quality)")
+
+    # Quality metric. For idealised: truth distance on freqs_sa (which
+    # IS selector-dependent). For real-data: SA-stage holdout MSE on the
+    # selected basis (not FA-stage — that would be selector-independent
+    # and uninformative).
+    print("  quality:")
+    if truth_freqs is not None:
+        for tag, out in outputs.items():
+            d = float(np.linalg.norm(out["freqs_sa"] - truth_freqs))
+            print(f"    ‖freqs_sa − truth‖_F  {tag:<10} = {d:.4e}")
+    else:
+        for tag, out in outputs.items():
+            mse, n_sa = _holdout_sa_mse(
+                cell, nhi, nhj, out["k_idxs"], out["l_idxs"],
+                prior=prior_for_compare, lmbda_sa=lmbda_sa,
+            )
+            print(f"    4-fold holdout SA-MSE  {tag:<10} = {mse:.4e}  "
+                  f"(SA basis size = {n_sa})")
+
+    # Side-by-side plot: input + 3 SA reconstructions.
+    plot_path = _plot_panels(
+        f"{name}_selectors",
+        arrays=[np.nan_to_num(cell.topo)] + [
+            np.nan_to_num(outputs[tag]["dat"]) for tag in selectors
+        ],
+        titles=["input"] + [f"SA: {tag}" for tag in selectors],
+        out_dir=OUTPUT_DIR,
+    )
+    print(f"  selector plot: {plot_path.relative_to(plot_path.parents[2])}")
+    return outputs
+
+
+def _plot_panels(name, arrays, titles, out_dir):
+    """Save a side-by-side PNG with ``len(arrays)`` panels."""
+    import matplotlib.pyplot as plt
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    arrays = [np.asarray(a) for a in arrays]
+    n = len(arrays)
+    fig, axes = plt.subplots(1, n, figsize=(5 * n, 5), constrained_layout=True)
+    if n == 1:
+        axes = [axes]
+    vmax = float(np.nanmax(np.abs(arrays[0])))
+    vmin = -vmax
+    for ax, arr, title in zip(axes, arrays, titles):
+        im = ax.imshow(arr, origin="lower", cmap="RdBu_r", vmin=vmin, vmax=vmax)
+        ax.set_title(title, fontsize=11)
+        ax.set_xticks([])
+        ax.set_yticks([])
+    fig.colorbar(im, ax=axes, shrink=0.8, label="elevation (relative)")
+    out_path = out_dir / f"{name}_reconstruction.png"
+    fig.savefig(out_path, dpi=120)
+    plt.close(fig)
+    return out_path
+
+
+def _diagnose(
+    name, cell, nhi, nhj, U, V, lmbda_fa, lmbda_sa, n_modes,
+    *, truth_freqs=None,
+):
+    """Run baseline vs hyperparam-selected pipeline and report metrics.
+
+    Quality metric branches on ``truth_freqs``:
+    - if supplied (idealised): reports ``‖freqs_sa − truth‖_F`` for
+      both pipelines — smaller is better.
+    - otherwise (real-data fixture): reports spatial 4-fold holdout
+      reconstruction MSE for both pipelines — smaller is better.
+    """
+    print(f"\n=== {name} ===")
+    M = _materialize_design_matrix(nhi, nhj, cell)
+    print(f"  design matrix shape: {M.shape}")
+
+    hp = build_spectral_prior(
+        topography=cell.topo,
+        design_matrix=M,
+        data=cell.topo_m,
+    )
+    if hp.slope_fit is not None:
+        print(
+            "  sequential: alpha = {:.3f}  (stderr={:.3f}, R²={:.3f}) ← "
+            "EmpiricalSpectralSlope".format(
+                hp.alpha, hp.slope_fit.stderr, hp.slope_fit.r_squared
+            )
+        )
+    else:
+        print(f"  sequential: alpha = {hp.alpha:.3f}  ← FixedAlpha")
+    print(f"  sequential: lambda = {hp.lmbda:.3e}  ← GCVSelector")
+
+    # Joint 2-D GCV: picks (alpha, lmbda) together from one held-out-
+    # error search. Independent comparison to the sequential pick;
+    # we don't replace hp because the rest of the diagnostic uses it.
+    hp_joint = build_spectral_prior(
+        topography=cell.topo,
+        design_matrix=M,
+        data=cell.topo_m,
+        joint_selector=JointGCVSelector(),
+    )
+    print(
+        f"  joint GCV:  alpha = {hp_joint.alpha:.3f}  "
+        f"lambda = {hp_joint.lmbda:.3e}  ← JointGCVSelector"
+    )
+    print(
+        "  baseline lmbda_fa = {:.3e}  lmbda_sa = {:.3e}".format(
+            lmbda_fa, lmbda_sa
+        )
+    )
+
+    # Three pipelines, identical mode-selection + SA paths, only the
+    # FA/SA prior+lmbda combination differs:
+    #   * baseline   — no prior; the fixture's production (lmbda_fa, lmbda_sa)
+    #   * isotropic  — IsotropicPrior at the GCV-selected lmbda (the "scale-only" control)
+    #   * selected   — SpectralPrior(alpha) at the GCV-selected lmbda (full new defaults)
+    # The isotropic-vs-selected comparison isolates the contribution of
+    # the per-mode structure from the contribution of just picking a
+    # different scalar lambda.
+    uw_base, freqs_sa_base, dat_base, k_base, l_base = _run_fa_sa(
+        nhi, nhj, U, V, cell,
+        lmbda_fa=lmbda_fa, lmbda_sa=lmbda_sa, n_modes=n_modes, prior=None,
+    )
+    uw_iso, freqs_sa_iso, dat_iso, k_iso, l_iso = _run_fa_sa(
+        nhi, nhj, U, V, cell,
+        lmbda_fa=hp.lmbda, lmbda_sa=hp.lmbda, n_modes=n_modes,
+        prior=IsotropicPrior(),
+    )
+    uw_sel, freqs_sa_sel, dat_sel, k_sel, l_sel = _run_fa_sa(
+        nhi, nhj, U, V, cell,
+        lmbda_fa=hp.lmbda, lmbda_sa=hp.lmbda, n_modes=n_modes, prior=hp.prior,
+    )
+    # Joint-GCV pipeline: uses hp_joint.prior + hp_joint.lmbda. When
+    # joint picks alpha=0 this reduces to isotropic@λ_joint; when it
+    # picks alpha>0 this is a non-trivial structured prior at a
+    # jointly-optimized scale.
+    uw_jnt, freqs_sa_jnt, dat_jnt, k_jnt, l_jnt = _run_fa_sa(
+        nhi, nhj, U, V, cell,
+        lmbda_fa=hp_joint.lmbda, lmbda_sa=hp_joint.lmbda, n_modes=n_modes,
+        prior=hp_joint.prior,
+    )
+
+    # ---- Difference summary vs baseline ----
+    norm_base = float(np.max(np.abs(uw_base))) or 1.0
+    print("  difference vs. baseline (uw_pmf ∞-norm, relative):")
+    print(
+        "    isotropic-at-selected-λ : {:.3e}".format(
+            float(np.max(np.abs(uw_iso - uw_base))) / norm_base
+        )
+    )
+    print(
+        "    selected (SpectralPrior): {:.3e}".format(
+            float(np.max(np.abs(uw_sel - uw_base))) / norm_base
+        )
+    )
+    print(
+        "    joint GCV (α,λ)         : {:.3e}".format(
+            float(np.max(np.abs(uw_jnt - uw_base))) / norm_base
+        )
+    )
+
+    # ---- Quality metric: improvement vs baseline ----
+    print("  quality vs. ground truth or held-out points:")
+    if truth_freqs is not None:
+        d_base = float(np.linalg.norm(freqs_sa_base - truth_freqs))
+        d_iso = float(np.linalg.norm(freqs_sa_iso - truth_freqs))
+        d_sel = float(np.linalg.norm(freqs_sa_sel - truth_freqs))
+        d_jnt = float(np.linalg.norm(freqs_sa_jnt - truth_freqs))
+        print(f"    ‖freqs_sa − truth‖_F")
+        print(f"      baseline                  = {d_base:.4e}")
+        print(f"      isotropic-at-selected-λ   = {d_iso:.4e}")
+        print(f"      selected (SpectralPrior)  = {d_sel:.4e}")
+        print(f"      joint GCV (α={hp_joint.alpha:.2f}, λ={hp_joint.lmbda:.2e})"
+              f" = {d_jnt:.4e}")
+        for tag, d in (("isotropic", d_iso), ("selected", d_sel),
+                       ("joint_GCV", d_jnt)):
+            if d_base > 0:
+                rel = (d_base - d) / d_base * 100.0
+                verdict = "better" if d < d_base else "worse" if d > d_base else "tie"
+                print(f"      {tag:<10} vs baseline = {rel:+.2f}%  ({verdict})")
+        # Structure-vs-scale isolation
+        if d_iso > 0:
+            structure_rel = (d_iso - d_sel) / d_iso * 100.0
+            print(
+                f"      structure-only effect (selected vs isotropic) = "
+                f"{structure_rel:+.2f}%  "
+                f"({'structure helps' if d_sel < d_iso else 'structure hurts' if d_sel > d_iso else 'tie'})"
+            )
+    else:
+        # SA-stage holdout: per pipeline, build the SA design matrix
+        # from the modes that pipeline's FA→greedy actually picked,
+        # then 4-fold-CV with the pipeline's own (prior, lmbda_sa).
+        # FA-stage holdout was an artifact — lmbda_fa=0 is by design,
+        # so FA isn't tasked with generalizing to held-out points.
+        mse_base, n_sa_base = _holdout_sa_mse(
+            cell, nhi, nhj, k_base, l_base,
+            prior=None, lmbda_sa=lmbda_sa,
+        )
+        mse_iso, n_sa_iso = _holdout_sa_mse(
+            cell, nhi, nhj, k_iso, l_iso,
+            prior=IsotropicPrior(), lmbda_sa=hp.lmbda,
+        )
+        mse_sel, n_sa_sel = _holdout_sa_mse(
+            cell, nhi, nhj, k_sel, l_sel,
+            prior=hp.prior, lmbda_sa=hp.lmbda,
+        )
+        mse_jnt, n_sa_jnt = _holdout_sa_mse(
+            cell, nhi, nhj, k_jnt, l_jnt,
+            prior=hp_joint.prior, lmbda_sa=hp_joint.lmbda,
+        )
+        print(f"    4-fold spatial holdout SA-MSE (correct metric — "
+              f"SA basis built from each pipeline's own picked modes)")
+        print(f"      baseline (λ_fa={lmbda_fa:.2e}, λ_sa={lmbda_sa:.2e}, no prior) "
+              f"= {mse_base:.4e}  (SA basis size = {n_sa_base})")
+        print(f"      isotropic-at-selected-λ              = {mse_iso:.4e}  "
+              f"(SA basis size = {n_sa_iso})")
+        print(f"      selected (SpectralPrior at GCV λ)    = {mse_sel:.4e}  "
+              f"(SA basis size = {n_sa_sel})")
+        print(f"      joint GCV (α={hp_joint.alpha:.2f}, λ={hp_joint.lmbda:.2e})"
+              f" = {mse_jnt:.4e}  (SA basis size = {n_sa_jnt})")
+        for tag, m in (("isotropic", mse_iso), ("selected", mse_sel),
+                       ("joint_GCV", mse_jnt)):
+            if mse_base > 0:
+                rel = (mse_base - m) / mse_base * 100.0
+                verdict = "better" if m < mse_base else "worse" if m > mse_base else "tie"
+                print(f"      {tag:<10} vs baseline = {rel:+.2f}%  ({verdict})")
+        # Structure-vs-scale isolation
+        if mse_iso > 0:
+            structure_rel = (mse_iso - mse_sel) / mse_iso * 100.0
+            print(
+                f"      structure-only effect (selected vs isotropic) = "
+                f"{structure_rel:+.2f}%  "
+                f"({'structure helps' if mse_sel < mse_iso else 'structure hurts' if mse_sel > mse_iso else 'tie'})"
+            )
+
+    # ---- Side-by-side topography (4 panels) ----
+    plot_path = _plot_panels(
+        name,
+        arrays=[
+            np.nan_to_num(cell.topo),
+            np.nan_to_num(dat_base),
+            np.nan_to_num(dat_iso),
+            np.nan_to_num(dat_sel),
+        ],
+        titles=[
+            "input (idealised: planted topo)" if truth_freqs is not None
+            else "input topography",
+            f"baseline (λ_fa={lmbda_fa:.0e})",
+            f"isotropic at GCV λ={hp.lmbda:.2e}",
+            f"selected: SpectralPrior(α={hp.alpha:.2f})",
+        ],
+        out_dir=OUTPUT_DIR,
+    )
+    print(f"  side-by-side plot: {plot_path.relative_to(plot_path.parents[2])}")
+    return {
+        "alpha": hp.alpha,
+        "lambda": hp.lmbda,
+    }
+
+
+def main(argv=None):
+    print("kernel-spike phase-2 default validation")
+    print("---------------------------------------")
+    print(
+        "Reports the alpha/lambda chosen by the documented defaults\n"
+        "(EmpiricalSpectralSlope + GCVSelector) on two fixtures, plus\n"
+        "‖Δuw_pmf‖∞ / ‖uw_pmf_baseline‖∞ vs. each fixture's existing\n"
+        "production pipeline (no prior, fixture lmbda)."
+    )
+
+    # ---- Idealised: numbers from runs/idealised_isosceles.py ----
+    cell_id, _ = _build_idealised_cell(nhi=12, nhj=12, seed=777)
+    truth_freqs = _build_idealised_freqs_ref(nhi=12, nhj=12, seed=777)
+    result = _diagnose(
+        "idealised",
+        cell_id,
+        nhi=12, nhj=12, U=1.0, V=1.0,
+        lmbda_fa=1.0e-1, lmbda_sa=1.0e-6, n_modes=14,
+        truth_freqs=truth_freqs,
+    )
+    # Selectors under the production regime, then under the
+    # isotropic-at-λ_GCV regime (which beat production on this fixture).
+    _selector_compare(
+        "idealised", cell_id,
+        nhi=12, nhj=12, U=1.0, V=1.0,
+        lmbda_fa=1.0e-1, lmbda_sa=1.0e-6, n_modes=14,
+        prior_for_compare=None, truth_freqs=truth_freqs,
+    )
+    _selector_compare(
+        "idealised_gcv", cell_id,
+        nhi=12, nhj=12, U=1.0, V=1.0,
+        lmbda_fa=result["lambda"], lmbda_sa=result["lambda"], n_modes=14,
+        prior_for_compare=IsotropicPrior(), truth_freqs=truth_freqs,
+    )
+
+    # ---- Aleutians MERIT: numbers from capture_regional_merit.py ----
+    try:
+        cell_al = _build_aleutians_cell()
+    except Exception as exc:
+        print(f"\n=== aleutians_merit (SKIPPED: {exc}) ===")
+        return 0
+    result = _diagnose(
+        "aleutians_merit",
+        cell_al,
+        nhi=24, nhj=48, U=10.0, V=0.0,
+        lmbda_fa=0.0, lmbda_sa=1.0e-1, n_modes=50,
+        truth_freqs=None,
+    )
+    _selector_compare(
+        "aleutians_merit", cell_al,
+        nhi=24, nhj=48, U=10.0, V=0.0,
+        lmbda_fa=0.0, lmbda_sa=1.0e-1, n_modes=50,
+        prior_for_compare=None, truth_freqs=None,
+    )
+    _selector_compare(
+        "aleutians_merit_gcv", cell_al,
+        nhi=24, nhj=48, U=10.0, V=0.0,
+        lmbda_fa=result["lambda"], lmbda_sa=result["lambda"], n_modes=50,
+        prior_for_compare=IsotropicPrior(), truth_freqs=None,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_hyperparam_defaults.py
+++ b/scripts/validate_hyperparam_defaults.py
@@ -126,9 +126,11 @@ def _dedupe_kl(k_idxs, l_idxs, target_n):
 def _build_idealised_cell(nhi: int = 12, nhj: int = 12, seed: int = 777):
     """Replicate runs.idealised_isosceles._build_cell + _generate_terrain.
 
-    Lifted inline so the script does not depend on importing internals
-    of ``runs/idealised_isosceles.py`` (which mutates global numpy seed
-    state). Equivalent topography, equivalent cell layout.
+    Returns ``(cell, triangle, remask_for_sa)``. The cell is left
+    **un-masked** (rectangular cover) so the FA fit runs on the full
+    grid; ``remask_for_sa`` closes over ``triangle`` and re-masks
+    the cell to the ICON triangle before the SA fit, matching the
+    canonical flow at ``runs/idealised_isosceles.py:141-167``.
     """
     np.random.seed(seed)
     sz = 25
@@ -164,10 +166,18 @@ def _build_idealised_cell(nhi: int = 12, nhj: int = 12, seed: int = 777):
                 nk_scaled * cell.lon_grid + nl_scaled * cell.lat_grid
             )
     triangle = utils.gen_triangle(lon_v, lat_v)
-    cell.get_masked(triangle=triangle)
+
+    # Start un-masked (rectangular cover) so FA sees the full grid.
+    cell.get_masked(mask=np.ones_like(cell.topo).astype("bool"))
     cell.wlat = float(np.diff(cell.lat).mean())
     cell.wlon = float(np.diff(cell.lon).mean())
-    return cell, triangle
+
+    def remask_for_sa(c):
+        c.get_masked(triangle=triangle)
+        c.wlat = float(np.diff(c.lat).mean())
+        c.wlon = float(np.diff(c.lon).mean())
+
+    return cell, triangle, remask_for_sa
 
 
 # ----------------------------------------------------------------------
@@ -179,9 +189,11 @@ def _build_aleutians_cell():
     """Reproduce ``tests/reproducibility/capture/capture_regional_merit._run_pipeline``
     up to the point where the rectangular-cover cell is ready.
 
-    Lifted rather than imported because the capture script's
-    ``_run_pipeline`` returns post-pipeline arrays; we want the cell
-    itself so we can build the design matrix for hyperparam selection.
+    Returns ``(cell, remask_for_sa)``. ``cell`` is the rectangular
+    cover (``rect=True``); ``remask_for_sa`` re-applies
+    ``utils.get_lat_lon_segments(..., rect=False)`` to constrain
+    subsequent fits to the ICON triangle. Matches the canonical
+    FA → mode-select → re-mask → SA flow in the capture script.
     """
     repo_root = Path(__file__).resolve().parents[1]
     fixture_dir = repo_root / "tests" / "reproducibility" / "fixtures" / "regional_merit"
@@ -213,7 +225,11 @@ def _build_aleutians_cell():
 
     cell = var.topo_cell()
     utils.get_lat_lon_segments(clat_verts, clon_verts, cell, topo, rect=True)
-    return cell
+
+    def remask_for_sa(c):
+        utils.get_lat_lon_segments(clat_verts, clon_verts, c, topo, rect=False)
+
+    return cell, remask_for_sa
 
 
 # ----------------------------------------------------------------------
@@ -236,19 +252,21 @@ def _materialize_design_matrix(nhi: int, nhj: int, cell):
 
 def _run_fa_sa(
     nhi, nhj, U, V, cell, *, lmbda_fa, lmbda_sa, n_modes, prior=None,
+    remask_for_sa=None,
 ):
-    """Run FA → greedy mode select → SA.
+    """Run FA (rectangular cover) → greedy mode select → re-mask to
+    ICON triangle → SA.
 
-    Returns ``(uw_sa, freqs_sa, dat_2D_sa, k_idxs, l_idxs)``. The
-    picked mode indices are returned so callers can rebuild the SA
-    design matrix later for SA-stage holdout evaluation. Threads
-    ``prior`` through both FA and SA via the inner ``get_pmf``'s
-    ComputeContext. Default ``prior=None`` reproduces the historical
-    behavior.
+    Returns ``(uw_sa, freqs_sa, dat_2D_sa, k_idxs, l_idxs)``.
+    ``remask_for_sa(cell)`` is the thunk returned by the cell-builder
+    that switches the cell from the rectangular cover to the
+    triangle-masked state. When ``None``, behaves as before (no
+    re-masking) — kept for backward compatibility but production
+    semantics require the thunk.
     """
     work_cell = deepcopy(cell)
 
-    # ---- FA ----
+    # ---- FA on the rectangular cover ----
     first_guess = interface.get_pmf(nhi, nhj, U, V)
     if prior is not None:
         first_guess.ctx.prior = prior
@@ -266,7 +284,11 @@ def _run_fa_sa(
     k_idxs = [p[1] for p in indices]
     l_idxs = [p[0] for p in indices]
 
-    # ---- SA ----
+    # ---- re-mask to ICON triangle before SA ----
+    if remask_for_sa is not None:
+        remask_for_sa(work_cell)
+
+    # ---- SA on the triangle-masked cell ----
     second_guess = interface.get_pmf(nhi, nhj, U, V)
     if prior is not None:
         second_guess.ctx.prior = prior
@@ -277,24 +299,96 @@ def _run_fa_sa(
     return uw_sa, freqs_sa, np.asarray(dat_2D), k_idxs, l_idxs
 
 
+def _pick_sa_lambda_via_gcv(
+    cell, nhi, nhj, k_idxs, l_idxs, *, remask_for_sa,
+):
+    """Run JointGCV on the *SA* design matrix and return Hyperparams.
+
+    The SA design matrix is built on the **triangle-masked** cell
+    using the modes that FA + greedy selected. GCV on this matrix is
+    methodologically tied to its leave-one-point-out approximation —
+    appropriate for IID-noise problems, but on spatially-correlated
+    topography tends to under-regularize because dropping one point
+    barely perturbs the fit. See
+    :func:`_pick_sa_lambda_via_spatial_cv` for a version that uses
+    the same notion of out-of-sample as the evaluation metric.
+    """
+    side_cell = deepcopy(cell)
+    if remask_for_sa is not None:
+        remask_for_sa(side_cell)
+    fobj_sa = fourier.f_trans(nhi, nhj)
+    fobj_sa.set_kls(k_idxs, l_idxs, recompute_nhij=False)
+    fobj_sa.do_full(side_cell)
+    M_sa = np.asarray(lin_reg.get_coeffs(fobj_sa, ctx=fobj_sa.ctx))
+    hp = build_spectral_prior(
+        topography=side_cell.topo,
+        design_matrix=M_sa,
+        data=np.asarray(side_cell.topo_m),
+        joint_selector=JointGCVSelector(),
+    )
+    return hp
+
+
+def _pick_sa_lambda_via_spatial_cv(
+    cell, nhi, nhj, k_idxs, l_idxs, *,
+    remask_for_sa, n_folds=4, buffer_fraction=0.05, rng_seed=0,
+):
+    """Pick λ via 4-fold spatial CV on the *SA* design matrix.
+
+    Matches the out-of-sample notion that the evaluation metric uses
+    (leave-one-spatial-patch-out), so the selector and the evaluator
+    agree on what "generalizes" means. Cost is ~4×–10× a single GCV
+    because each candidate λ requires k_folds full ridge fits, but
+    still tractable per cell (~seconds for a 100-mode SA basis).
+    """
+    from pycsa.core.hyperparams import (
+        FixedAlpha,
+        SpatialCVSelector,
+        build_spectral_prior,
+    )
+
+    side_cell = deepcopy(cell)
+    if remask_for_sa is not None:
+        remask_for_sa(side_cell)
+    fobj_sa = fourier.f_trans(nhi, nhj)
+    fobj_sa.set_kls(k_idxs, l_idxs, recompute_nhij=False)
+    fobj_sa.do_full(side_cell)
+    M_sa = np.asarray(lin_reg.get_coeffs(fobj_sa, ctx=fobj_sa.ctx))
+    coords = np.column_stack(
+        [np.asarray(side_cell.lon_m), np.asarray(side_cell.lat_m)]
+    )
+    selector = SpatialCVSelector(
+        coords=coords, n_folds=n_folds, buffer_fraction=buffer_fraction,
+        rng_seed=rng_seed,
+    )
+    hp = build_spectral_prior(
+        topography=side_cell.topo,
+        design_matrix=M_sa,
+        data=np.asarray(side_cell.topo_m),
+        alpha_selector=FixedAlpha(0.0),
+        lambda_selector=selector,
+    )
+    return hp
+
+
 def _holdout_sa_mse(
     cell, nhi, nhj, k_idxs, l_idxs, *, prior, lmbda_sa,
-    n_folds=4, buffer_fraction=0.05,
+    n_folds=4, buffer_fraction=0.05, remask_for_sa=None,
 ):
     """4-fold spatial holdout MSE for an SA fit on a specified mode set.
 
-    Builds the SA design matrix on the cell using the supplied
-    ``(k_idxs, l_idxs)``, then runs :func:`spatial_cv_score` against
-    held-out spatial patches. Uses the supplied ``prior`` + ``lmbda_sa``
+    Builds the SA design matrix on the triangle-masked cell (after
+    applying ``remask_for_sa``), then runs :func:`spatial_cv_score`
+    against held-out spatial patches. Uses ``prior`` + ``lmbda_sa``
     for the per-fold ridge fit.
 
     This is the correct out-of-sample metric for the pipeline: SA is
     where regularization is consumed, and the SA basis is what the
-    downstream physics actually uses. (FA-stage holdout is an
-    artifact because ``lmbda_fa=0`` is by design — FA is a feature
-    extractor for mode selection, not a generalization-target step.)
+    downstream physics actually uses on the constrained ICON cell.
     """
     side_cell = deepcopy(cell)
+    if remask_for_sa is not None:
+        remask_for_sa(side_cell)
     fobj_sa = fourier.f_trans(nhi, nhj)
     fobj_sa.set_kls(k_idxs, l_idxs, recompute_nhij=False)
     fobj_sa.do_full(side_cell)
@@ -348,13 +442,14 @@ def _build_idealised_freqs_ref(nhi: int = 12, nhj: int = 12, seed: int = 777):
 
 def _run_fa_then_selector(
     nhi, nhj, U, V, cell, *, lmbda_fa, lmbda_sa, n_modes, prior, selector,
+    remask_for_sa=None,
 ):
-    """Run FA, then use ``selector`` (instead of inline argmax) to pick
-    modes, then SA. Returns (uw_sa, freqs_sa, dat_2D_sa).
+    """Run FA (rectangular cover) → selector → re-mask → SA.
 
-    Mirrors ``_run_fa_sa`` but calls a pluggable selector. The selector
-    receives the FA spectrum AND the FA design matrix + data — OMP and
-    Lasso need them; GreedyArgmax ignores them.
+    Mirrors ``_run_fa_sa`` but calls a pluggable selector instead of
+    the inline argmax loop. The selector receives the FA spectrum
+    AND the FA design matrix + data — OMP and Lasso need them;
+    GreedyArgmax ignores them.
     """
     work_cell = deepcopy(cell)
 
@@ -394,6 +489,10 @@ def _run_fa_then_selector(
                 if len(k_idxs) == n_modes:
                     break
 
+    # Re-mask to ICON triangle before SA (matches production).
+    if remask_for_sa is not None:
+        remask_for_sa(work_cell)
+
     second_guess = interface.get_pmf(nhi, nhj, U, V)
     if prior is not None:
         second_guess.ctx.prior = prior
@@ -406,7 +505,7 @@ def _run_fa_then_selector(
 
 def _selector_compare(
     name, cell, nhi, nhj, U, V, lmbda_fa, lmbda_sa, n_modes,
-    *, prior_for_compare, truth_freqs,
+    *, prior_for_compare, truth_freqs, remask_for_sa=None,
 ):
     """Compare Greedy / OMP / Lasso on the same (prior, lmbda) setting.
 
@@ -433,6 +532,7 @@ def _selector_compare(
             nhi, nhj, U, V, cell,
             lmbda_fa=lmbda_fa, lmbda_sa=lmbda_sa, n_modes=n_modes,
             prior=prior_for_compare, selector=sel,
+            remask_for_sa=remask_for_sa,
         )
         outputs[tag] = {
             "uw": uw, "freqs_sa": freqs_sa, "dat": dat,
@@ -461,6 +561,7 @@ def _selector_compare(
             mse, n_sa = _holdout_sa_mse(
                 cell, nhi, nhj, out["k_idxs"], out["l_idxs"],
                 prior=prior_for_compare, lmbda_sa=lmbda_sa,
+                remask_for_sa=remask_for_sa,
             )
             print(f"    4-fold holdout SA-MSE  {tag:<10} = {mse:.4e}  "
                   f"(SA basis size = {n_sa})")
@@ -504,7 +605,7 @@ def _plot_panels(name, arrays, titles, out_dir):
 
 def _diagnose(
     name, cell, nhi, nhj, U, V, lmbda_fa, lmbda_sa, n_modes,
-    *, truth_freqs=None,
+    *, truth_freqs=None, remask_for_sa=None,
 ):
     """Run baseline vs hyperparam-selected pipeline and report metrics.
 
@@ -564,15 +665,17 @@ def _diagnose(
     uw_base, freqs_sa_base, dat_base, k_base, l_base = _run_fa_sa(
         nhi, nhj, U, V, cell,
         lmbda_fa=lmbda_fa, lmbda_sa=lmbda_sa, n_modes=n_modes, prior=None,
+        remask_for_sa=remask_for_sa,
     )
     uw_iso, freqs_sa_iso, dat_iso, k_iso, l_iso = _run_fa_sa(
         nhi, nhj, U, V, cell,
         lmbda_fa=hp.lmbda, lmbda_sa=hp.lmbda, n_modes=n_modes,
-        prior=IsotropicPrior(),
+        prior=IsotropicPrior(), remask_for_sa=remask_for_sa,
     )
     uw_sel, freqs_sa_sel, dat_sel, k_sel, l_sel = _run_fa_sa(
         nhi, nhj, U, V, cell,
         lmbda_fa=hp.lmbda, lmbda_sa=hp.lmbda, n_modes=n_modes, prior=hp.prior,
+        remask_for_sa=remask_for_sa,
     )
     # Joint-GCV pipeline: uses hp_joint.prior + hp_joint.lmbda. When
     # joint picks alpha=0 this reduces to isotropic@λ_joint; when it
@@ -581,7 +684,7 @@ def _diagnose(
     uw_jnt, freqs_sa_jnt, dat_jnt, k_jnt, l_jnt = _run_fa_sa(
         nhi, nhj, U, V, cell,
         lmbda_fa=hp_joint.lmbda, lmbda_sa=hp_joint.lmbda, n_modes=n_modes,
-        prior=hp_joint.prior,
+        prior=hp_joint.prior, remask_for_sa=remask_for_sa,
     )
 
     # ---- Difference summary vs baseline ----
@@ -638,19 +741,21 @@ def _diagnose(
         # so FA isn't tasked with generalizing to held-out points.
         mse_base, n_sa_base = _holdout_sa_mse(
             cell, nhi, nhj, k_base, l_base,
-            prior=None, lmbda_sa=lmbda_sa,
+            prior=None, lmbda_sa=lmbda_sa, remask_for_sa=remask_for_sa,
         )
         mse_iso, n_sa_iso = _holdout_sa_mse(
             cell, nhi, nhj, k_iso, l_iso,
             prior=IsotropicPrior(), lmbda_sa=hp.lmbda,
+            remask_for_sa=remask_for_sa,
         )
         mse_sel, n_sa_sel = _holdout_sa_mse(
             cell, nhi, nhj, k_sel, l_sel,
-            prior=hp.prior, lmbda_sa=hp.lmbda,
+            prior=hp.prior, lmbda_sa=hp.lmbda, remask_for_sa=remask_for_sa,
         )
         mse_jnt, n_sa_jnt = _holdout_sa_mse(
             cell, nhi, nhj, k_jnt, l_jnt,
             prior=hp_joint.prior, lmbda_sa=hp_joint.lmbda,
+            remask_for_sa=remask_for_sa,
         )
         print(f"    4-fold spatial holdout SA-MSE (correct metric — "
               f"SA basis built from each pipeline's own picked modes)")
@@ -713,33 +818,35 @@ def main(argv=None):
     )
 
     # ---- Idealised: numbers from runs/idealised_isosceles.py ----
-    cell_id, _ = _build_idealised_cell(nhi=12, nhj=12, seed=777)
+    cell_id, _triangle, remask_id = _build_idealised_cell(
+        nhi=12, nhj=12, seed=777
+    )
     truth_freqs = _build_idealised_freqs_ref(nhi=12, nhj=12, seed=777)
     result = _diagnose(
         "idealised",
         cell_id,
         nhi=12, nhj=12, U=1.0, V=1.0,
         lmbda_fa=1.0e-1, lmbda_sa=1.0e-6, n_modes=14,
-        truth_freqs=truth_freqs,
+        truth_freqs=truth_freqs, remask_for_sa=remask_id,
     )
-    # Selectors under the production regime, then under the
-    # isotropic-at-λ_GCV regime (which beat production on this fixture).
     _selector_compare(
         "idealised", cell_id,
         nhi=12, nhj=12, U=1.0, V=1.0,
         lmbda_fa=1.0e-1, lmbda_sa=1.0e-6, n_modes=14,
         prior_for_compare=None, truth_freqs=truth_freqs,
+        remask_for_sa=remask_id,
     )
     _selector_compare(
         "idealised_gcv", cell_id,
         nhi=12, nhj=12, U=1.0, V=1.0,
         lmbda_fa=result["lambda"], lmbda_sa=result["lambda"], n_modes=14,
         prior_for_compare=IsotropicPrior(), truth_freqs=truth_freqs,
+        remask_for_sa=remask_id,
     )
 
     # ---- Aleutians MERIT: numbers from capture_regional_merit.py ----
     try:
-        cell_al = _build_aleutians_cell()
+        cell_al, remask_al = _build_aleutians_cell()
     except Exception as exc:
         print(f"\n=== aleutians_merit (SKIPPED: {exc}) ===")
         return 0
@@ -748,19 +855,21 @@ def main(argv=None):
         cell_al,
         nhi=24, nhj=48, U=10.0, V=0.0,
         lmbda_fa=0.0, lmbda_sa=1.0e-1, n_modes=50,
-        truth_freqs=None,
+        truth_freqs=None, remask_for_sa=remask_al,
     )
     _selector_compare(
         "aleutians_merit", cell_al,
         nhi=24, nhj=48, U=10.0, V=0.0,
         lmbda_fa=0.0, lmbda_sa=1.0e-1, n_modes=50,
         prior_for_compare=None, truth_freqs=None,
+        remask_for_sa=remask_al,
     )
     _selector_compare(
         "aleutians_merit_gcv", cell_al,
         nhi=24, nhj=48, U=10.0, V=0.0,
         lmbda_fa=result["lambda"], lmbda_sa=result["lambda"], n_modes=50,
         prior_for_compare=IsotropicPrior(), truth_freqs=None,
+        remask_for_sa=remask_al,
     )
     return 0
 

--- a/tests/test_hyperparams.py
+++ b/tests/test_hyperparams.py
@@ -22,7 +22,6 @@ from pycsa.core.hyperparams import (
 )
 from pycsa.core.priors import SpectralPrior
 
-
 # -----------------------------------------------------------------------------
 # Synthetic helpers
 # -----------------------------------------------------------------------------
@@ -131,9 +130,7 @@ def test_fixed_lambda_passthrough():
 def test_gcv_returns_positive_finite_lambda():
     M, rng = _simple_design(n_points=80, n_modes=15)
     y = M @ rng.normal(size=15) + 0.05 * rng.normal(size=80)
-    lam = GCVSelector()(
-        M, y, alpha=0.0, prior_factory=_trial_prior_factory
-    )
+    lam = GCVSelector()(M, y, alpha=0.0, prior_factory=_trial_prior_factory)
     assert np.isfinite(lam)
     assert lam > 0.0
 
@@ -174,9 +171,7 @@ def test_marginal_likelihood_agrees_with_gcv_in_gaussian_regime():
     M, rng = _simple_design(n_points=400, n_modes=30, seed=9)
     truth = rng.normal(size=30)
     y = M @ truth + 0.1 * rng.normal(size=400)
-    lam_gcv = GCVSelector()(
-        M, y, alpha=0.0, prior_factory=_trial_prior_factory
-    )
+    lam_gcv = GCVSelector()(M, y, alpha=0.0, prior_factory=_trial_prior_factory)
     lam_ml = MarginalLikelihoodSelector()(
         M, y, alpha=0.0, prior_factory=_trial_prior_factory
     )
@@ -226,9 +221,7 @@ def test_build_spectral_prior_with_fixed_alpha_skips_slope_fit():
     field = rng.normal(size=(48, 48))
     M, _ = _simple_design(n_points=field.size, n_modes=20, seed=2)
     y = field.ravel()
-    hp = build_spectral_prior(
-        field, M, y, alpha_selector=FixedAlpha(1.5)
-    )
+    hp = build_spectral_prior(field, M, y, alpha_selector=FixedAlpha(1.5))
     assert hp.alpha == 1.5
     assert hp.slope_fit is None
 
@@ -239,7 +232,9 @@ def test_build_spectral_prior_with_fixed_lambda_returns_that_lambda():
     M, _ = _simple_design(n_points=field.size, n_modes=15, seed=3)
     y = field.ravel()
     hp = build_spectral_prior(
-        field, M, y,
+        field,
+        M,
+        y,
         alpha_selector=FixedAlpha(0.0),
         lambda_selector=FixedLambda(0.123),
     )
@@ -272,10 +267,14 @@ def test_joint_gcv_with_alpha_zero_only_matches_gcv_selector():
     y = M @ rng.normal(size=18) + 0.05 * rng.normal(size=160)
     grid = np.logspace(-6, 1, 21)
     _, lam_joint = JointGCVSelector(
-        alpha_grid=np.array([0.0]), lambda_grid=grid,
+        alpha_grid=np.array([0.0]),
+        lambda_grid=grid,
     )(M, y)
     lam_solo = GCVSelector(lambda_grid=grid)(
-        M, y, alpha=0.0, prior_factory=lambda a: SpectralPrior(alpha=a),
+        M,
+        y,
+        alpha=0.0,
+        prior_factory=lambda a: SpectralPrior(alpha=a),
     )
     # Both run on the same eigendecomp + grid — should match exactly.
     np.testing.assert_allclose(lam_joint, lam_solo)
@@ -287,7 +286,9 @@ def test_build_spectral_prior_joint_mode_returns_hyperparams():
     M, _ = _simple_design(n_points=field.size, n_modes=20, seed=7)
     y = field.ravel() + 0.01 * rng.normal(size=field.size)
     hp = build_spectral_prior(
-        field, M, y,
+        field,
+        M,
+        y,
         joint_selector=JointGCVSelector(
             alpha_grid=np.array([0.0, 1.0, 2.0]),
         ),

--- a/tests/test_hyperparams.py
+++ b/tests/test_hyperparams.py
@@ -1,0 +1,299 @@
+"""Unit tests for pycsa.core.hyperparams.
+
+Exercise each selector at the protocol level on synthetic problems
+with known answers. End-to-end validation against the real fixtures
+is the job of scripts/validate_hyperparam_defaults.py, not these.
+"""
+
+import numpy as np
+import pytest
+
+from pycsa.core.hyperparams import (
+    EmpiricalSpectralSlope,
+    FixedAlpha,
+    FixedLambda,
+    GCVSelector,
+    Hyperparams,
+    JointGCVSelector,
+    MarginalLikelihoodSelector,
+    SpatialCVSelector,
+    SlopeFit,
+    build_spectral_prior,
+)
+from pycsa.core.priors import SpectralPrior
+
+
+# -----------------------------------------------------------------------------
+# Synthetic helpers
+# -----------------------------------------------------------------------------
+
+
+def _planted_power_law_field(shape, beta, rng):
+    """Generate a 2D field whose periodogram follows ``P(k) ∝ k^(-beta)``.
+
+    Build amplitudes ``|F(k)| ∝ k^(-beta/2)`` with random phases,
+    then inverse-FFT to the spatial domain. The resulting field is
+    real (we symmetrize) and its empirical periodogram should match
+    the planted slope within sampling noise.
+    """
+    ny, nx = shape
+    ky = np.fft.fftfreq(ny)[:, None]
+    kx = np.fft.fftfreq(nx)[None, :]
+    kmag = np.hypot(ky, kx)
+    kmag[0, 0] = 1.0  # avoid div-by-zero at DC
+    amp = kmag ** (-beta / 2.0)
+    amp[0, 0] = 0.0  # zero out DC
+    phase = rng.uniform(0, 2 * np.pi, size=shape)
+    F = amp * np.exp(1j * phase)
+    field = np.fft.ifft2(F).real
+    return field
+
+
+def _simple_design(n_points=120, n_modes=20, seed=0):
+    """Random Gaussian design matrix with unit-norm columns."""
+    rng = np.random.default_rng(seed)
+    M = rng.normal(size=(n_points, n_modes))
+    M /= np.linalg.norm(M, axis=0, keepdims=True)
+    return M, rng
+
+
+# -----------------------------------------------------------------------------
+# Alpha selectors
+# -----------------------------------------------------------------------------
+
+
+def test_fixed_alpha_passthrough():
+    assert FixedAlpha(1.7)(np.zeros((4, 4))) == 1.7
+
+
+def test_empirical_slope_recovers_planted_power_law():
+    rng = np.random.default_rng(42)
+    target_beta = 2.0
+    field = _planted_power_law_field((128, 128), beta=target_beta, rng=rng)
+    fit = EmpiricalSpectralSlope()(field)
+    assert isinstance(fit, SlopeFit)
+    assert abs(fit.alpha - target_beta) < 0.3
+    assert fit.stderr >= 0.0
+    assert 0.0 <= fit.r_squared <= 1.0
+
+
+def test_empirical_slope_returns_stderr_and_r2():
+    """Whatever the recovered slope is, the returned record must
+    carry usable stderr and R² (so downstream callers can detect
+    poorly-fit fields)."""
+    rng = np.random.default_rng(7)
+    field = rng.normal(size=(64, 64))  # white noise — flat spectrum
+    fit = EmpiricalSpectralSlope()(field)
+    assert np.isfinite(fit.stderr)
+    assert np.isfinite(fit.r_squared)
+
+
+def test_empirical_slope_raises_on_1d_input():
+    with pytest.raises(ValueError, match="2D"):
+        EmpiricalSpectralSlope()(np.zeros(64))
+
+
+def test_empirical_slope_stable_across_band_perturbations():
+    """β should not move much when the fit band is widened/narrowed
+    by reasonable amounts — checks the +/- stderr is meaningful."""
+    rng = np.random.default_rng(11)
+    field = _planted_power_law_field((128, 128), beta=2.0, rng=rng)
+    fits = [
+        EmpiricalSpectralSlope(k_min_frac=0.02, k_max_frac=0.4)(field),
+        EmpiricalSpectralSlope(k_min_frac=0.03, k_max_frac=0.5)(field),
+        EmpiricalSpectralSlope(k_min_frac=0.04, k_max_frac=0.45)(field),
+    ]
+    alphas = np.array([f.alpha for f in fits])
+    # Spread should be on the order of the largest reported stderr.
+    max_stderr = max(f.stderr for f in fits)
+    assert alphas.std() < max(5 * max_stderr, 0.3)
+
+
+# -----------------------------------------------------------------------------
+# Lambda selectors
+# -----------------------------------------------------------------------------
+
+
+def _trial_prior_factory(alpha):
+    return SpectralPrior(alpha=alpha)
+
+
+def test_fixed_lambda_passthrough():
+    val = FixedLambda(0.42)(
+        design_matrix=np.zeros((4, 3)),
+        data=np.zeros(4),
+        alpha=0.0,
+        prior_factory=_trial_prior_factory,
+    )
+    assert val == 0.42
+
+
+def test_gcv_returns_positive_finite_lambda():
+    M, rng = _simple_design(n_points=80, n_modes=15)
+    y = M @ rng.normal(size=15) + 0.05 * rng.normal(size=80)
+    lam = GCVSelector()(
+        M, y, alpha=0.0, prior_factory=_trial_prior_factory
+    )
+    assert np.isfinite(lam)
+    assert lam > 0.0
+
+
+def test_gcv_prefers_smaller_lambda_at_high_snr():
+    """At very high SNR, GCV should prefer near-zero regularization."""
+    M, rng = _simple_design(n_points=200, n_modes=20, seed=3)
+    truth = rng.normal(size=20)
+    y_clean = M @ truth
+    y_noisy = y_clean + 0.5 * rng.normal(size=200)
+
+    lam_high_snr = GCVSelector()(
+        M, y_clean, alpha=0.0, prior_factory=_trial_prior_factory
+    )
+    lam_low_snr = GCVSelector()(
+        M, y_noisy, alpha=0.0, prior_factory=_trial_prior_factory
+    )
+    # High-SNR lambda should be no larger than low-SNR lambda.
+    # Loose bound — GCV grids are coarse — but the ordering should hold.
+    assert lam_high_snr <= 1.5 * lam_low_snr or lam_high_snr < 1e-4
+
+
+def test_marginal_likelihood_returns_positive_finite_lambda():
+    M, rng = _simple_design(n_points=80, n_modes=15, seed=5)
+    y = M @ rng.normal(size=15) + 0.05 * rng.normal(size=80)
+    lam = MarginalLikelihoodSelector()(
+        M, y, alpha=0.0, prior_factory=_trial_prior_factory
+    )
+    assert np.isfinite(lam)
+    assert lam > 0.0
+
+
+def test_marginal_likelihood_agrees_with_gcv_in_gaussian_regime():
+    """Under homoscedastic Gaussian noise the two selectors should agree
+    within ~half a decade. (Diverge under heteroscedastic / non-Gaussian
+    residuals — that's the documented regime where MarginalLikelihood
+    is preferred.)"""
+    M, rng = _simple_design(n_points=400, n_modes=30, seed=9)
+    truth = rng.normal(size=30)
+    y = M @ truth + 0.1 * rng.normal(size=400)
+    lam_gcv = GCVSelector()(
+        M, y, alpha=0.0, prior_factory=_trial_prior_factory
+    )
+    lam_ml = MarginalLikelihoodSelector()(
+        M, y, alpha=0.0, prior_factory=_trial_prior_factory
+    )
+    # log10 ratio within 0.7 ≈ within factor of 5. Loose because both
+    # selectors have edge-case behavior near small lambda.
+    assert abs(np.log10(lam_gcv) - np.log10(lam_ml)) < 0.7
+
+
+def test_spatial_cv_selector_returns_positive_finite_lambda():
+    rng = np.random.default_rng(13)
+    n_points = 200
+    M = rng.normal(size=(n_points, 20))
+    y = M @ rng.normal(size=20) + 0.1 * rng.normal(size=n_points)
+    # Random 2D coords for the spatial fold builder
+    coords = rng.uniform(0, 1, size=(n_points, 2))
+    lam = SpatialCVSelector(coords=coords, n_folds=4)(
+        M, y, alpha=0.0, prior_factory=_trial_prior_factory
+    )
+    assert np.isfinite(lam)
+    assert lam > 0.0
+
+
+# -----------------------------------------------------------------------------
+# build_spectral_prior end-to-end
+# -----------------------------------------------------------------------------
+
+
+def test_build_spectral_prior_defaults_return_hyperparams_record():
+    rng = np.random.default_rng(0)
+    field = _planted_power_law_field((64, 64), beta=2.0, rng=rng)
+    M, _ = _simple_design(n_points=field.size, n_modes=30, seed=4)
+    y = field.ravel() + 0.01 * rng.normal(size=field.size)
+    hp = build_spectral_prior(field, M, y)
+    assert isinstance(hp, Hyperparams)
+    assert np.isfinite(hp.alpha)
+    assert np.isfinite(hp.lmbda)
+    assert hp.lmbda > 0.0
+    assert isinstance(hp.prior, SpectralPrior)
+    assert hp.prior.alpha == hp.alpha
+    # Default uses EmpiricalSpectralSlope ⇒ slope_fit populated
+    assert hp.slope_fit is not None
+    assert hp.slope_fit.alpha == hp.alpha
+
+
+def test_build_spectral_prior_with_fixed_alpha_skips_slope_fit():
+    rng = np.random.default_rng(1)
+    field = rng.normal(size=(48, 48))
+    M, _ = _simple_design(n_points=field.size, n_modes=20, seed=2)
+    y = field.ravel()
+    hp = build_spectral_prior(
+        field, M, y, alpha_selector=FixedAlpha(1.5)
+    )
+    assert hp.alpha == 1.5
+    assert hp.slope_fit is None
+
+
+def test_build_spectral_prior_with_fixed_lambda_returns_that_lambda():
+    rng = np.random.default_rng(2)
+    field = rng.normal(size=(32, 32))
+    M, _ = _simple_design(n_points=field.size, n_modes=15, seed=3)
+    y = field.ravel()
+    hp = build_spectral_prior(
+        field, M, y,
+        alpha_selector=FixedAlpha(0.0),
+        lambda_selector=FixedLambda(0.123),
+    )
+    assert hp.lmbda == 0.123
+
+
+# -----------------------------------------------------------------------------
+# JointGCVSelector
+# -----------------------------------------------------------------------------
+
+
+def test_joint_gcv_returns_finite_pair_within_grids():
+    """Joint GCV should pick (alpha, lmbda) inside its grid bounds and
+    return finite values."""
+    M, rng = _simple_design(n_points=120, n_modes=20, seed=4)
+    y = M @ rng.normal(size=20) + 0.05 * rng.normal(size=120)
+    alpha, lmbda = JointGCVSelector(
+        alpha_grid=np.array([0.0, 1.0, 2.0]),
+    )(M, y)
+    assert 0.0 <= alpha <= 2.0
+    assert np.isfinite(lmbda)
+    assert lmbda > 0.0
+
+
+def test_joint_gcv_with_alpha_zero_only_matches_gcv_selector():
+    """If the alpha grid contains only 0, JointGCV reduces to plain
+    1-D GCV over lambda — should give a similar lambda as
+    GCVSelector on the same data."""
+    M, rng = _simple_design(n_points=160, n_modes=18, seed=5)
+    y = M @ rng.normal(size=18) + 0.05 * rng.normal(size=160)
+    grid = np.logspace(-6, 1, 21)
+    _, lam_joint = JointGCVSelector(
+        alpha_grid=np.array([0.0]), lambda_grid=grid,
+    )(M, y)
+    lam_solo = GCVSelector(lambda_grid=grid)(
+        M, y, alpha=0.0, prior_factory=lambda a: SpectralPrior(alpha=a),
+    )
+    # Both run on the same eigendecomp + grid — should match exactly.
+    np.testing.assert_allclose(lam_joint, lam_solo)
+
+
+def test_build_spectral_prior_joint_mode_returns_hyperparams():
+    rng = np.random.default_rng(6)
+    field = rng.normal(size=(40, 40))
+    M, _ = _simple_design(n_points=field.size, n_modes=20, seed=7)
+    y = field.ravel() + 0.01 * rng.normal(size=field.size)
+    hp = build_spectral_prior(
+        field, M, y,
+        joint_selector=JointGCVSelector(
+            alpha_grid=np.array([0.0, 1.0, 2.0]),
+        ),
+    )
+    assert isinstance(hp, Hyperparams)
+    assert hp.slope_fit is None  # joint mode skips the slope fit
+    assert hp.alpha in (0.0, 1.0, 2.0)
+    assert np.isfinite(hp.lmbda) and hp.lmbda > 0.0
+    assert hp.prior.alpha == hp.alpha

--- a/tests/test_mode_selection.py
+++ b/tests/test_mode_selection.py
@@ -1,0 +1,146 @@
+"""Unit tests for pycsa.core.mode_selection.
+
+Cover the protocol-level behavior of GreedyArgmax (bit-equivalent to
+the inline loop), OMPSelector (planted-mode recovery on a deterministic
+fixture), and LassoSelector (returns ≤ n_modes indices with finite
+coefficients). End-to-end pipeline behavior is the gate's job, not
+these tests'.
+"""
+
+import numpy as np
+import pytest
+
+from pycsa.core.mode_selection import (
+    GreedyArgmax,
+    LassoSelector,
+    OMPSelector,
+)
+
+
+def _greedy_inline_loop(fa_spectrum, n_modes):
+    """Verbatim replica of the inline loop at interface.py:556-571.
+
+    Used as the ground truth for the GreedyArgmax parity test.
+    """
+    fq = np.copy(fa_spectrum)
+    indices = []
+    while len(indices) < n_modes:
+        max_idx = np.unravel_index(fq.argmax(), fq.shape)
+        indices.append(max_idx)
+        fq[max_idx] = 0.0
+    k_idxs = [pair[1] for pair in indices]
+    l_idxs = [pair[0] for pair in indices]
+    return k_idxs, l_idxs
+
+
+def test_greedy_argmax_matches_inline_loop():
+    """GreedyArgmax produces bit-identical (k_idxs, l_idxs) to the
+    historical inline loop on a synthetic FA spectrum.
+    """
+    rng = np.random.default_rng(0)
+    fa = rng.uniform(0, 1, size=(6, 8))  # (nhar_j, nhar_i) convention
+    fa[2, 3] = 10.0  # plant a dominant mode
+    fa[5, 1] = 7.5
+    fa[0, 7] = 5.0
+
+    k_inline, l_inline = _greedy_inline_loop(fa, n_modes=5)
+    k_sel, l_sel = GreedyArgmax()(fa, n_modes=5)
+    assert k_sel == k_inline
+    assert l_sel == l_inline
+
+
+def test_greedy_argmax_handles_uniform_spectrum():
+    """When the spectrum is constant, argmax always picks the first
+    flat element. The selector should follow numpy's tiebreaking,
+    same as the inline loop.
+    """
+    fa = np.ones((3, 3))
+    k_inline, l_inline = _greedy_inline_loop(fa, n_modes=4)
+    k_sel, l_sel = GreedyArgmax()(fa, n_modes=4)
+    assert (k_sel, l_sel) == (k_inline, l_inline)
+
+
+def test_omp_recovers_planted_modes():
+    """Plant 3 modes in a small Fourier design matrix and verify OMP
+    recovers their column indices.
+
+    Synthetic setup: M is a random Gaussian matrix (this stands in for
+    the design matrix without going through f_trans); y = M @ a* + tiny
+    noise, where a* has exactly 3 non-zero entries.
+    """
+    rng = np.random.default_rng(42)
+    n_points = 200
+    n_cols = 30
+    M = rng.normal(size=(n_points, n_cols))
+    M /= np.linalg.norm(M, axis=0, keepdims=True)  # unit-norm columns
+
+    truth = np.zeros(n_cols)
+    planted = [3, 11, 22]
+    truth[planted] = [2.0, -1.5, 1.0]
+    y = M @ truth + 1e-4 * rng.normal(size=n_points)
+
+    # FA spectrum is unused by OMP — pass a placeholder shape
+    # consistent with the spectrum convention. column_to_kl is provided
+    # so we can verify the recovered indices directly.
+    placeholder_spectrum = np.zeros((5, 6))  # nhar_j=5, nhar_i=6 → 30 cols
+    recovered_columns: list[int] = []
+
+    def column_to_kl(c):
+        recovered_columns.append(c)
+        return (c % 6, c // 6)
+
+    k_idxs, l_idxs = OMPSelector()(
+        placeholder_spectrum,
+        n_modes=3,
+        design_matrix=M,
+        data=y,
+        column_to_kl=column_to_kl,
+    )
+    assert sorted(recovered_columns) == sorted(planted)
+
+
+def test_omp_raises_without_design_matrix():
+    fa = np.zeros((4, 4))
+    with pytest.raises(ValueError, match="design_matrix"):
+        OMPSelector()(fa, n_modes=2)
+
+
+def test_omp_batch_mode_returns_n_modes():
+    """Batched OMP returns exactly n_modes columns, even if the batch
+    size doesn't divide cleanly.
+    """
+    rng = np.random.default_rng(1)
+    M = rng.normal(size=(80, 20))
+    y = M[:, 3] + 0.5 * M[:, 7] + 1e-3 * rng.normal(size=80)
+    fa = np.zeros((4, 5))
+    k_idxs, l_idxs = OMPSelector(batch_size=3)(
+        fa, n_modes=5, design_matrix=M, data=y
+    )
+    assert len(k_idxs) == 5
+    assert len(l_idxs) == 5
+
+
+def test_lasso_selector_returns_n_modes():
+    """LassoSelector returns exactly n_modes indices on a synthetic
+    problem with a clear sparse support.
+    """
+    pytest.importorskip("sklearn")
+    rng = np.random.default_rng(7)
+    M = rng.normal(size=(120, 25))
+    M /= np.linalg.norm(M, axis=0, keepdims=True)
+    truth = np.zeros(25)
+    truth[[2, 9, 15]] = [1.5, -0.8, 1.0]
+    y = M @ truth + 1e-3 * rng.normal(size=120)
+    fa = np.zeros((5, 5))
+    k_idxs, l_idxs = LassoSelector()(
+        fa, n_modes=3, design_matrix=M, data=y
+    )
+    assert len(k_idxs) == 3
+    assert len(l_idxs) == 3
+
+
+def test_lasso_selector_raises_without_design_matrix():
+    pytest.importorskip("sklearn")
+    fa = np.zeros((4, 4))
+    with pytest.raises(ValueError, match="design_matrix"):
+        LassoSelector()(fa, n_modes=2)

--- a/tests/test_mode_selection.py
+++ b/tests/test_mode_selection.py
@@ -113,9 +113,7 @@ def test_omp_batch_mode_returns_n_modes():
     M = rng.normal(size=(80, 20))
     y = M[:, 3] + 0.5 * M[:, 7] + 1e-3 * rng.normal(size=80)
     fa = np.zeros((4, 5))
-    k_idxs, l_idxs = OMPSelector(batch_size=3)(
-        fa, n_modes=5, design_matrix=M, data=y
-    )
+    k_idxs, l_idxs = OMPSelector(batch_size=3)(fa, n_modes=5, design_matrix=M, data=y)
     assert len(k_idxs) == 5
     assert len(l_idxs) == 5
 
@@ -132,9 +130,7 @@ def test_lasso_selector_returns_n_modes():
     truth[[2, 9, 15]] = [1.5, -0.8, 1.0]
     y = M @ truth + 1e-3 * rng.normal(size=120)
     fa = np.zeros((5, 5))
-    k_idxs, l_idxs = LassoSelector()(
-        fa, n_modes=3, design_matrix=M, data=y
-    )
+    k_idxs, l_idxs = LassoSelector()(fa, n_modes=3, design_matrix=M, data=y)
     assert len(k_idxs) == 3
     assert len(l_idxs) == 3
 

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -1,0 +1,138 @@
+"""Unit tests for pycsa.core.priors.
+
+These tests cover the protocol-level behavior of the pluggable Tikhonov
+diagonal generators introduced in the phase-1 spike skeleton. They do
+NOT exercise the full pipeline — those checks live in
+tests/reproducibility/ and must remain green with the new code path
+absent (default ``prior=None``).
+"""
+
+import numpy as np
+import pytest
+
+from pycsa.core import lin_reg
+from pycsa.core.priors import IsotropicPrior, SpectralPrior
+
+
+class _StubFobj:
+    """Minimal fobj-like object exposing the attributes priors read.
+
+    Real ``f_trans`` instances carry far more state; we only need
+    ``m_i``, ``m_j``, and the optional ``pick_kls`` / ``k_idx`` /
+    ``l_idx`` slots.
+    """
+
+    def __init__(self, m_i, m_j, pick_kls=False, k_idx=None, l_idx=None):
+        self.m_i = np.asarray(m_i)
+        self.m_j = np.asarray(m_j)
+        self.pick_kls = pick_kls
+        if k_idx is not None:
+            self.k_idx = np.asarray(k_idx)
+        if l_idx is not None:
+            self.l_idx = np.asarray(l_idx)
+
+
+def _spd_matrix(n, seed=0):
+    """Random SPD matrix for use as a stand-in ``E_tilda_lm``."""
+    rng = np.random.default_rng(seed)
+    A = rng.normal(size=(n, n))
+    return A @ A.T + n * np.eye(n)
+
+
+def test_isotropic_matches_inline_branch_dense():
+    """IsotropicPrior produces a diagonal equal to the inline branch."""
+    E = _spd_matrix(8)
+    lmbda = 0.5
+    prior = IsotropicPrior()
+    diag = prior(fobj=None, E_tilda_lm=E, lmbda=lmbda)
+    # Inline branch at lin_reg.py:193-195 computes:
+    #     trace = np.trace(E) / E.shape[0] * lmbda
+    # then adds this scalar to every diagonal entry.
+    expected_scalar = np.trace(E) / E.shape[0] * lmbda
+    assert diag.shape == (E.shape[0],)
+    np.testing.assert_allclose(diag, expected_scalar)
+
+
+def test_isotropic_zero_lambda_returns_zero():
+    diag = IsotropicPrior()(fobj=None, E_tilda_lm=_spd_matrix(4), lmbda=0.0)
+    np.testing.assert_array_equal(diag, np.zeros(4))
+
+
+def test_lin_reg_do_with_isotropic_prior_equals_default(monkeypatch):
+    """lin_reg.do(prior=IsotropicPrior()) ~= lin_reg.do(prior=None).
+
+    Within floating-point reassociation noise; the inline branch uses
+    one scalar and broadcasts via fill_diagonal, while IsotropicPrior
+    returns an N-vector that we add via fill_diagonal — same final
+    numerical state.
+    """
+    from pycsa.core.fourier import f_trans
+    from pycsa.core import var
+
+    # Build a small idealised cell + fobj to drive lin_reg.do end-to-end.
+    cell = var.topo_cell()
+    n = 16
+    cell.lon_m = np.tile(np.linspace(0, 1, n), n)
+    cell.lat_m = np.repeat(np.linspace(0, 1, n), n)
+    cell.lon = np.linspace(0, 1, n)
+    cell.lat = np.linspace(0, 1, n)
+    cell.wlon = 1.0 / (n - 1)
+    cell.wlat = 1.0 / (n - 1)
+    cell.topo_m = np.cos(2 * np.pi * cell.lon_m) + 0.3 * np.sin(
+        4 * np.pi * cell.lat_m
+    )
+
+    fobj = f_trans(4, 4)
+    fobj.do_full(cell)
+    a_default, recons_default = lin_reg.do(fobj, cell, lmbda=0.1, prior=None)
+
+    fobj2 = f_trans(4, 4)
+    fobj2.do_full(cell)
+    a_iso, recons_iso = lin_reg.do(
+        fobj2, cell, lmbda=0.1, prior=IsotropicPrior()
+    )
+
+    np.testing.assert_allclose(a_default, a_iso, rtol=1e-10, atol=1e-12)
+    np.testing.assert_allclose(recons_default, recons_iso, rtol=1e-10, atol=1e-12)
+
+
+def test_spectral_prior_alpha_zero_is_almost_isotropic():
+    """SpectralPrior(alpha=0) is the constant ``(1+eps)^0 = 1`` weight,
+    so trace_scale * 1 * ones — matches IsotropicPrior exactly.
+    """
+    E = _spd_matrix(12, seed=1)
+    fobj = _StubFobj(m_i=np.arange(4), m_j=np.arange(-1, 3))
+    iso = IsotropicPrior()(fobj=fobj, E_tilda_lm=E, lmbda=0.25)
+    sp = SpectralPrior(alpha=0.0)(fobj=fobj, E_tilda_lm=E, lmbda=0.25)
+    np.testing.assert_allclose(sp, iso)
+
+
+def test_spectral_prior_monotone_in_alpha():
+    """For alpha>0 the diagonal grows with ``‖k‖``; pick a fobj where
+    ‖k_m‖ has an unambiguous max and min and check ordering.
+    """
+    E = _spd_matrix(8, seed=2)
+    # m_i in 0..3, m_j in -1..2 → ‖k‖ ranges from 0 to sqrt(9+4)=sqrt(13)
+    fobj = _StubFobj(m_i=np.arange(4), m_j=np.arange(-1, 3))
+    diag = SpectralPrior(alpha=2.0)(fobj=fobj, E_tilda_lm=E, lmbda=1.0)
+    # Largest weight should appear at columns mapping to high ‖k‖, smallest
+    # at the DC corner (which is bounded below by eps>0 — never exactly 0).
+    assert diag.min() > 0.0
+    assert diag.max() > diag.min()
+
+
+def test_spectral_prior_eps_floor_keeps_dc_positive():
+    """The +eps floor guarantees positive regularization even at k=0."""
+    E = _spd_matrix(4, seed=3)
+    # Single-mode setup: forces a column whose weight would be exactly 0
+    # without the eps floor.
+    fobj = _StubFobj(
+        m_i=np.array([0]),
+        m_j=np.array([0]),
+        pick_kls=True,
+        k_idx=[0],
+        l_idx=[0],
+    )
+    sp = SpectralPrior(alpha=2.0, eps=1e-3)
+    diag = sp(fobj=fobj, E_tilda_lm=E, lmbda=1.0)
+    assert np.all(diag > 0.0)

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -78,9 +78,7 @@ def test_lin_reg_do_with_isotropic_prior_equals_default(monkeypatch):
     cell.lat = np.linspace(0, 1, n)
     cell.wlon = 1.0 / (n - 1)
     cell.wlat = 1.0 / (n - 1)
-    cell.topo_m = np.cos(2 * np.pi * cell.lon_m) + 0.3 * np.sin(
-        4 * np.pi * cell.lat_m
-    )
+    cell.topo_m = np.cos(2 * np.pi * cell.lon_m) + 0.3 * np.sin(4 * np.pi * cell.lat_m)
 
     fobj = f_trans(4, 4)
     fobj.do_full(cell)
@@ -88,9 +86,7 @@ def test_lin_reg_do_with_isotropic_prior_equals_default(monkeypatch):
 
     fobj2 = f_trans(4, 4)
     fobj2.do_full(cell)
-    a_iso, recons_iso = lin_reg.do(
-        fobj2, cell, lmbda=0.1, prior=IsotropicPrior()
-    )
+    a_iso, recons_iso = lin_reg.do(fobj2, cell, lmbda=0.1, prior=IsotropicPrior())
 
     np.testing.assert_allclose(a_default, a_iso, rtol=1e-10, atol=1e-12)
     np.testing.assert_allclose(recons_default, recons_iso, rtol=1e-10, atol=1e-12)

--- a/tests/test_spatial_cv.py
+++ b/tests/test_spatial_cv.py
@@ -1,0 +1,145 @@
+"""Unit tests for pycsa.core.validation.spatial_cv_score.
+
+Cover fold construction (no leakage through buffer; balanced sizes;
+raises on too-sparse or zero-extent coords) and the scoring loop
+(finite per-fold MSE; mean = mean(per_fold)).
+"""
+
+import numpy as np
+import pytest
+
+from pycsa.core.priors import IsotropicPrior, SpectralPrior
+from pycsa.core.validation import _build_spatial_folds, spatial_cv_score
+
+
+def _grid_coords(n_per_side):
+    """Regular n×n coord grid in [0, 1] × [0, 1]."""
+    xs = np.linspace(0.0, 1.0, n_per_side)
+    ys = np.linspace(0.0, 1.0, n_per_side)
+    XY = np.array(np.meshgrid(xs, ys, indexing="ij"))
+    return XY.reshape(2, -1).T  # shape (n_per_side**2, 2)
+
+
+def test_build_spatial_folds_returns_disjoint_eval_sets():
+    """No coord index appears in more than one fold's eval set."""
+    coords = _grid_coords(20)
+    folds = _build_spatial_folds(
+        coords, n_folds=4, buffer_fraction=0.0, rng_seed=0
+    )
+    seen = set()
+    for _, eval_idx in folds:
+        eval_set = set(eval_idx.tolist())
+        assert seen.isdisjoint(eval_set), "fold eval sets overlap"
+        seen |= eval_set
+
+
+def test_build_spatial_folds_buffer_excludes_from_both():
+    """A non-zero buffer means buffer points are absent from both
+    train_idx and eval_idx of that fold."""
+    coords = _grid_coords(30)
+    folds = _build_spatial_folds(
+        coords, n_folds=4, buffer_fraction=0.1, rng_seed=1
+    )
+    for train_idx, eval_idx in folds:
+        # train ∩ eval is empty
+        assert not (set(train_idx.tolist()) & set(eval_idx.tolist()))
+        # train ∪ eval covers fewer than all coords (buffer was excised)
+        n = coords.shape[0]
+        assert len(set(train_idx.tolist()) | set(eval_idx.tolist())) < n
+
+
+def test_build_spatial_folds_returns_n_folds():
+    coords = _grid_coords(15)
+    folds = _build_spatial_folds(
+        coords, n_folds=5, buffer_fraction=0.05, rng_seed=2
+    )
+    assert len(folds) == 5
+    for train_idx, eval_idx in folds:
+        assert train_idx.size > 1
+        assert eval_idx.size > 0
+
+
+def test_build_spatial_folds_raises_on_zero_extent():
+    coords = np.column_stack([np.zeros(20), np.linspace(0, 1, 20)])
+    with pytest.raises(ValueError, match="zero extent"):
+        _build_spatial_folds(coords, n_folds=4, buffer_fraction=0.1, rng_seed=0)
+
+
+def test_build_spatial_folds_raises_on_too_few_points():
+    coords = _grid_coords(2)  # 4 points
+    with pytest.raises(ValueError, match="at least"):
+        _build_spatial_folds(coords, n_folds=5, buffer_fraction=0.0, rng_seed=0)
+
+
+def test_spatial_cv_score_basic_shape():
+    """Returns the documented dict structure with finite numbers."""
+    rng = np.random.default_rng(0)
+    coords = _grid_coords(20)  # 400 points
+    n = coords.shape[0]
+    M = rng.normal(size=(n, 25))
+    truth = rng.normal(size=25)
+    y = M @ truth + 0.1 * rng.normal(size=n)
+
+    result = spatial_cv_score(
+        prior=IsotropicPrior(),
+        lmbda=0.1,
+        design_matrix=M,
+        data=y,
+        coords=coords,
+        n_folds=4,
+        buffer_fraction=0.05,
+        rng_seed=42,
+    )
+    assert "per_fold_mse" in result
+    assert "mean_heldout_mse" in result
+    assert "fold_sizes" in result
+    assert result["per_fold_mse"].shape == (4,)
+    assert np.all(np.isfinite(result["per_fold_mse"]))
+    np.testing.assert_allclose(
+        result["mean_heldout_mse"], float(np.mean(result["per_fold_mse"]))
+    )
+    # fold_sizes is (n_train, n_eval) per fold; both should be > 0
+    assert np.all(result["fold_sizes"] > 0)
+
+
+def test_spatial_cv_score_isotropic_vs_strong_regularization():
+    """Stronger regularization should *not* make held-out MSE arbitrarily
+    smaller — the validation is supposed to detect over-regularization.
+    """
+    rng = np.random.default_rng(0)
+    coords = _grid_coords(20)
+    n = coords.shape[0]
+    M = rng.normal(size=(n, 25))
+    truth = rng.normal(size=25)
+    y = M @ truth + 0.05 * rng.normal(size=n)
+
+    mse_light = spatial_cv_score(
+        prior=IsotropicPrior(),
+        lmbda=1e-4,
+        design_matrix=M, data=y, coords=coords,
+        n_folds=4, buffer_fraction=0.05, rng_seed=0,
+    )["mean_heldout_mse"]
+    mse_heavy = spatial_cv_score(
+        prior=IsotropicPrior(),
+        lmbda=1e3,
+        design_matrix=M, data=y, coords=coords,
+        n_folds=4, buffer_fraction=0.05, rng_seed=0,
+    )["mean_heldout_mse"]
+    # Heavy regularization → underfit → larger held-out MSE.
+    assert mse_heavy > mse_light
+
+
+def test_spatial_cv_score_works_with_spectral_prior():
+    """SpectralPrior should be a valid plug-in. Smoke test only."""
+    rng = np.random.default_rng(0)
+    coords = _grid_coords(15)
+    n = coords.shape[0]
+    M = rng.normal(size=(n, 20))
+    y = M @ rng.normal(size=20) + 0.05 * rng.normal(size=n)
+    result = spatial_cv_score(
+        prior=SpectralPrior(alpha=1.5),
+        lmbda=0.01,
+        design_matrix=M, data=y, coords=coords,
+        n_folds=4, buffer_fraction=0.05, rng_seed=1,
+    )
+    assert np.all(np.isfinite(result["per_fold_mse"]))

--- a/tests/test_spatial_cv.py
+++ b/tests/test_spatial_cv.py
@@ -23,9 +23,7 @@ def _grid_coords(n_per_side):
 def test_build_spatial_folds_returns_disjoint_eval_sets():
     """No coord index appears in more than one fold's eval set."""
     coords = _grid_coords(20)
-    folds = _build_spatial_folds(
-        coords, n_folds=4, buffer_fraction=0.0, rng_seed=0
-    )
+    folds = _build_spatial_folds(coords, n_folds=4, buffer_fraction=0.0, rng_seed=0)
     seen = set()
     for _, eval_idx in folds:
         eval_set = set(eval_idx.tolist())
@@ -37,9 +35,7 @@ def test_build_spatial_folds_buffer_excludes_from_both():
     """A non-zero buffer means buffer points are absent from both
     train_idx and eval_idx of that fold."""
     coords = _grid_coords(30)
-    folds = _build_spatial_folds(
-        coords, n_folds=4, buffer_fraction=0.1, rng_seed=1
-    )
+    folds = _build_spatial_folds(coords, n_folds=4, buffer_fraction=0.1, rng_seed=1)
     for train_idx, eval_idx in folds:
         # train ∩ eval is empty
         assert not (set(train_idx.tolist()) & set(eval_idx.tolist()))
@@ -50,9 +46,7 @@ def test_build_spatial_folds_buffer_excludes_from_both():
 
 def test_build_spatial_folds_returns_n_folds():
     coords = _grid_coords(15)
-    folds = _build_spatial_folds(
-        coords, n_folds=5, buffer_fraction=0.05, rng_seed=2
-    )
+    folds = _build_spatial_folds(coords, n_folds=5, buffer_fraction=0.05, rng_seed=2)
     assert len(folds) == 5
     for train_idx, eval_idx in folds:
         assert train_idx.size > 1
@@ -116,14 +110,22 @@ def test_spatial_cv_score_isotropic_vs_strong_regularization():
     mse_light = spatial_cv_score(
         prior=IsotropicPrior(),
         lmbda=1e-4,
-        design_matrix=M, data=y, coords=coords,
-        n_folds=4, buffer_fraction=0.05, rng_seed=0,
+        design_matrix=M,
+        data=y,
+        coords=coords,
+        n_folds=4,
+        buffer_fraction=0.05,
+        rng_seed=0,
     )["mean_heldout_mse"]
     mse_heavy = spatial_cv_score(
         prior=IsotropicPrior(),
         lmbda=1e3,
-        design_matrix=M, data=y, coords=coords,
-        n_folds=4, buffer_fraction=0.05, rng_seed=0,
+        design_matrix=M,
+        data=y,
+        coords=coords,
+        n_folds=4,
+        buffer_fraction=0.05,
+        rng_seed=0,
     )["mean_heldout_mse"]
     # Heavy regularization → underfit → larger held-out MSE.
     assert mse_heavy > mse_light
@@ -139,7 +141,11 @@ def test_spatial_cv_score_works_with_spectral_prior():
     result = spatial_cv_score(
         prior=SpectralPrior(alpha=1.5),
         lmbda=0.01,
-        design_matrix=M, data=y, coords=coords,
-        n_folds=4, buffer_fraction=0.05, rng_seed=1,
+        design_matrix=M,
+        data=y,
+        coords=coords,
+        n_folds=4,
+        buffer_fraction=0.05,
+        rng_seed=1,
     )
     assert np.all(np.isfinite(result["per_fold_mse"]))


### PR DESCRIPTION
## Summary

Opt-in extension points for structured Tikhonov priors + sparsity-inducing mode selection (Phases 1 + 2 of the kernel-spike work), plus data-driven SA-stage λ via `SpatialCVSelector` — +3.3% Aleutians, +6.5% south_pole on 4-fold spatial holdout MSE vs production. Defaults unchanged; reproducibility gate stays green.

Follows PR #50 (Phase C publication-readiness, merged 2026-05-17).

## Commits

| commit | gist |
|---|---|
| `06e6af6` | Phase 1: `Prior` + `ModeSelector` protocols + concrete implementations (`IsotropicPrior`, `SpectralPrior`, `GreedyArgmax`, `OMPSelector`, `LassoSelector`). Opt-in via `lin_reg.do(prior=…)` and `interface.second_appx(selector=…)`. |
| `93d5314` | Phase 2: `AlphaSelector`/`LambdaSelector` protocols + `GCVSelector`, `JointGCVSelector`, `MarginalLikelihoodSelector`, `SpatialCVSelector`; `spatial_cv_score` utility; `build_spectral_prior`. |
| `3f040ab` | CI: `diagnostic-plots` job — per-PR baseline-vs-new-defaults PNG artifacts. |
| `02515e2` | SA semantics fix: SA fits the triangle-masked cell (matches `runs/idealised_isosceles.py` and the capture scripts); SA-stage λ picked on the SA design matrix via SpatialCV. |
| `6b1ea69` | Add cell elevation to NetCDF output. |

## Empirical findings (`scripts/compare_baseline_vs_new_defaults.py`)

4-fold spatial holdout SA-MSE, lower-is-better:

| fixture | production | SA-GCV | SA-SpatialCV |
|---|---|---|---|
| idealised | 4435 | 4433 | **4411** (+0.6%) |
| aleutians | 8154 | 30 560 (broken) | **7888** (+3.3%) |
| south_pole | 6290 | 11 530 (broken) | **5884** (+6.5%) |

`JointGCVSelector` picks α=0 on every fixture — structured per-mode regularization isn't data-supported here. GCV-on-SA under-regularizes spatially-correlated data (its leave-one-point-out approximation is broken when neighbors carry the same information). `SpatialCVSelector` uses the same notion of out-of-sample as the evaluation metric and converges on production's hand-tuned λ within ~3× on Aleutians (0.30 vs 0.10), and picks per-cell on south_pole.

## Defaults unchanged

Nothing here is on the production code path. New behavior is opt-in via `lin_reg.do(prior=…)`, `interface.second_appx(selector=…)`, or threading through `ComputeContext.prior` / `.selector`. The 3 reproducibility fixtures stay green throughout (no drift beyond the pre-existing LAPACK noise).

## Test plan

- [x] `pytest tests/reproducibility/` green (3 fixtures)
- [x] `pytest tests/test_priors.py tests/test_mode_selection.py tests/test_hyperparams.py tests/test_spatial_cv.py` — 35 unit tests pass
- [x] `scripts/compare_baseline_vs_new_defaults.py` runs end-to-end on idealised + Aleutians + south_pole
- [x] CI matrix reproducibility job (py3.10/3.11/3.12) green
- [x] CI `diagnostic-plots` artifact uploaded (verify in Actions tab)

## Deferred

- Per-cell `SpatialCVSelector` wiring into HPC drivers (`runs/icon_etopo_global.py` / `runs/icon_merit_global.py`) — after Levante validation.